### PR TITLE
feat(frontend): add entity-based append support in UI

### DIFF
--- a/backend/app/models/entity.py
+++ b/backend/app/models/entity.py
@@ -80,12 +80,25 @@ class FilterConfig(BaseModel):
 
 
 class AppendConfig(BaseModel):
-    """Configuration for appending data to an entity."""
+    """Configuration for appending data to an entity.
 
-    type: Literal["fixed", "sql"] = Field(..., description="Type of data to append")
-    values: list[list[Any]] | None = Field(default=None, description="Fixed values to append")
-    data_source: str | None = Field(default=None, description="Data source name for SQL")
-    query: str | None = Field(default=None, description="SQL query for appending data")
+    Supports three append strategies:
+    1. type='fixed': Hardcoded values to append
+    2. type='sql': SQL query results to append
+    3. source: Rows from another entity to append
+    """
+
+    # Type-based append (fixed or sql)
+    type: Literal["fixed", "sql"] | None = Field(default=None, description="Type of data to append (fixed or sql)")
+    values: list[list[Any]] | None = Field(default=None, description="Fixed values to append (for type='fixed')")
+    data_source: str | None = Field(default=None, description="Data source name for SQL (for type='sql')")
+    query: str | None = Field(default=None, description="SQL query for appending data (for type='sql')")
+
+    # Entity-based append (source)
+    source: str | None = Field(default=None, description="Entity name to append rows from")
+    columns: list[str] | None = Field(default=None, description="Columns to append (inherits from parent if not specified)")
+    align_by_position: bool = Field(default=False, description="Align columns by position instead of name")
+    column_mapping: dict[str, str] | None = Field(default=None, description="Explicit column name mapping (source_col: target_col)")
 
 
 class Entity(BaseModel):

--- a/frontend/src/components/entities/AppendEditor.vue
+++ b/frontend/src/components/entities/AppendEditor.vue
@@ -4,37 +4,130 @@
       <v-list-item v-for="(item, index) in append" :key="index" class="px-0 mb-2">
         <v-card variant="outlined">
           <v-card-text>
-            <div class="d-flex align-center justify-space-between mb-2">
+            <!-- Header: Type selector + Delete button -->
+            <div class="d-flex align-center justify-space-between mb-3">
               <v-select
                 v-model="item.type"
                 :items="appendTypes"
                 label="Append Type"
                 variant="outlined"
                 density="compact"
-                style="max-width: 200px"
+                style="max-width: 250px"
               />
               <v-btn icon="mdi-delete" variant="text" size="small" color="error" @click="handleRemoveAppend(index)" />
             </div>
 
-            <v-textarea
-              v-if="item.type === 'fixed'"
-              v-model="item.valuesText"
-              label="Values (JSON Array)"
-              hint='Example: [["value1", "value2"], ["value3", "value4"]]'
-              persistent-hint
-              variant="outlined"
-              rows="3"
-            />
+            <!-- Fixed Values Type -->
+            <template v-if="item.appendType === 'fixed'">
+              <v-textarea
+                v-model="item.valuesText"
+                label="Values (JSON Array)"
+                hint='Example: [["value1", "value2"], ["value3", "value4"]]'
+                persistent-hint
+                variant="outlined"
+                rows="3"
+              />
+            </template>
 
-            <template v-else-if="item.type === 'sql'">
+            <!-- SQL Query Type -->
+            <template v-else-if="item.appendType === 'sql'">
               <v-text-field
                 v-model="item.data_source"
                 label="Data Source"
                 variant="outlined"
                 density="compact"
                 class="mb-2"
+                hint="Data source name from project configuration"
+                persistent-hint
               />
-              <v-textarea v-model="item.query" label="SQL Query" variant="outlined" rows="4" />
+              <v-textarea
+                v-model="item.query"
+                label="SQL Query"
+                variant="outlined"
+                rows="4"
+                hint="SQL query to append data from"
+                persistent-hint
+              />
+            </template>
+
+            <!-- Entity Source Type -->
+            <template v-else-if="item.appendType === 'entity'">
+              <div class="mb-3">
+                <v-select
+                  v-model="item.source"
+                  :items="availableEntities"
+                  label="Source Entity"
+                  variant="outlined"
+                  density="compact"
+                  hint="Select an existing entity to append rows from"
+                  persistent-hint
+                />
+              </div>
+
+              <!-- Column Alignment Options -->
+              <v-expansion-panels density="compact" class="mb-3">
+                <v-expansion-panel>
+                  <template #title>
+                    <v-icon size="small" class="mr-2">mdi-cog</v-icon>
+                    <span class="text-caption">Column Alignment Options</span>
+                  </template>
+                  <v-expansion-panel-text>
+                    <div class="pt-2">
+                      <v-checkbox
+                        v-model="item.align_by_position"
+                        label="Align by position"
+                        density="compact"
+                        hide-details
+                        class="mb-2"
+                        @update:model-value="handleAlignByPositionChange(item)"
+                      />
+                      <v-divider class="my-2" />
+                      <p class="text-caption mb-2">
+                        <strong>Column Mapping:</strong> Explicitly map source columns to target columns
+                      </p>
+                      <v-text-field
+                        v-for="(targetCol, sourceCol) in item.column_mapping || {}"
+                        :key="sourceCol"
+                        :label="`${sourceCol} →`"
+                        :model-value="targetCol"
+                        variant="outlined"
+                        density="compact"
+                        class="mb-2"
+                        hint="Target column name"
+                        persistent-hint
+                        @update:model-value="updateColumnMapping(item, sourceCol, $event)"
+                      />
+                      <v-btn
+                        size="small"
+                        variant="tonal"
+                        prepend-icon="mdi-plus"
+                        @click="addColumnMapping(item)"
+                        class="mt-2"
+                      >
+                        Add Mapping
+                      </v-btn>
+                    </div>
+                  </v-expansion-panel-text>
+                </v-expansion-panel>
+              </v-expansion-panels>
+
+              <!-- Column Override -->
+              <v-checkbox
+                v-model="item.showColumnsOverride"
+                label="Override inherited columns"
+                density="compact"
+                hide-details
+                class="mb-2"
+              />
+              <v-textarea
+                v-if="item.showColumnsOverride"
+                v-model="item.columnsText"
+                label="Columns (JSON Array)"
+                hint='Example: ["col1", "col2", "col3"]'
+                persistent-hint
+                variant="outlined"
+                rows="2"
+              />
             </template>
           </v-card-text>
         </v-card>
@@ -48,61 +141,181 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { ref, watch, computed } from 'vue'
 
-interface AppendConfig {
-  type: 'fixed' | 'sql'
+interface AppendConfigInternal {
+  type?: 'fixed' | 'sql' | 'entity'
+  appendType?: 'fixed' | 'sql' | 'entity' // Computed from type or source
   values?: any[][]
   valuesText?: string
   data_source?: string
   query?: string
+  source?: string
+  columns?: string[]
+  columnsText?: string
+  showColumnsOverride?: boolean
+  align_by_position?: boolean
+  column_mapping?: Record<string, string>
 }
 
 interface Props {
-  modelValue?: AppendConfig[]
+  modelValue?: AppendConfigInternal[]
+  availableEntities?: string[]
 }
 
 const props = withDefaults(defineProps<Props>(), {
   modelValue: () => [],
+  availableEntities: () => [],
 })
 
 const emit = defineEmits<{
-  'update:modelValue': [value: AppendConfig[] | undefined]
+  'update:modelValue': [value: AppendConfigInternal[] | undefined]
 }>()
 
-const append = ref<AppendConfig[]>(props.modelValue || [])
+const append = ref<AppendConfigInternal[]>([])
 
 const appendTypes = [
   { title: 'Fixed Values', value: 'fixed' },
   { title: 'SQL Query', value: 'sql' },
+  { title: 'From Entity', value: 'entity' },
 ]
 
-function handleAddAppend() {
+const availableEntities = computed(() => props.availableEntities || [])
+
+/**
+ * Initialize append items, detecting whether they use type-based or source-based approach
+ */
+function initializeAppendItems(): void {
+  if (!props.modelValue) {
+    append.value = []
+    return
+  }
+
+  append.value = props.modelValue.map((item) => {
+    const initialized: AppendConfigInternal = { ...item }
+
+    // Determine appendType based on the config structure
+    if (item.source) {
+      initialized.appendType = 'entity'
+    } else if (item.type === 'fixed') {
+      initialized.appendType = 'fixed'
+      if (item.values && !item.valuesText) {
+        initialized.valuesText = JSON.stringify(item.values, null, 2)
+      }
+    } else if (item.type === 'sql') {
+      initialized.appendType = 'sql'
+    }
+
+    // For columns override
+    if (item.columns && !item.columnsText) {
+      initialized.columnsText = JSON.stringify(item.columns, null, 2)
+    }
+
+    return initialized
+  })
+}
+
+function handleAddAppend(): void {
   append.value.push({
     type: 'fixed',
+    appendType: 'fixed',
     valuesText: '',
   })
 }
 
-function handleRemoveAppend(index: number) {
+function handleRemoveAppend(index: number): void {
   append.value.splice(index, 1)
+}
+
+function handleAlignByPositionChange(item: AppendConfigInternal): void {
+  if (item.align_by_position && item.column_mapping) {
+    // Clear column mapping when switching to align_by_position
+    item.column_mapping = undefined
+  }
+}
+
+function addColumnMapping(item: AppendConfigInternal): void {
+  if (!item.column_mapping) {
+    item.column_mapping = {}
+  }
+  item.column_mapping['source_column'] = 'target_column'
+}
+
+function updateColumnMapping(item: AppendConfigInternal, sourceCol: string, targetCol: string): void {
+  if (!item.column_mapping) {
+    item.column_mapping = {}
+  }
+  if (targetCol) {
+    item.column_mapping[sourceCol] = targetCol
+  } else {
+    delete item.column_mapping[sourceCol]
+  }
+}
+
+/**
+ * Convert internal format back to API format
+ */
+function normalizeForAPI(): (AppendConfigInternal | null)[] {
+  return append.value.map((item) => {
+    const normalized: Record<string, any> = {}
+
+    // Always set append type
+    if (item.appendType === 'fixed') {
+      normalized.type = 'fixed'
+      if (item.valuesText) {
+        try {
+          normalized.values = JSON.parse(item.valuesText)
+        } catch {
+          // Invalid JSON - will be caught by backend validation
+          normalized.values = []
+        }
+      }
+    } else if (item.appendType === 'sql') {
+      normalized.type = 'sql'
+      if (item.data_source) normalized.data_source = item.data_source
+      if (item.query) normalized.query = item.query
+    } else if (item.appendType === 'entity') {
+      normalized.source = item.source
+      if (item.showColumnsOverride && item.columnsText) {
+        try {
+          normalized.columns = JSON.parse(item.columnsText)
+        } catch {
+          // Invalid JSON - will be caught by backend validation
+        }
+      }
+      if (item.align_by_position) normalized.align_by_position = true
+      if (item.column_mapping && Object.keys(item.column_mapping).length > 0) {
+        normalized.column_mapping = item.column_mapping
+      }
+    }
+
+    return Object.keys(normalized).length > 0 ? (normalized as AppendConfigInternal) : null
+  }).filter((item): item is AppendConfigInternal => item !== null)
 }
 
 watch(
   append,
-  (newValue) => {
-    emit('update:modelValue', newValue.length > 0 ? newValue : undefined)
+  () => {
+    const normalized = normalizeForAPI()
+    emit('update:modelValue', normalized.length > 0 ? normalized : undefined)
   },
   { deep: true }
 )
 
 watch(
   () => props.modelValue,
-  (newValue) => {
-    if (newValue) {
-      append.value = newValue
-    }
+  () => {
+    initializeAppendItems()
   },
   { deep: true }
 )
+
+// Initialize on mount
+initializeAppendItems()
 </script>
+
+<style scoped>
+.text-caption {
+  font-size: 0.75rem;
+}
+</style>

--- a/frontend/src/components/entities/EntityFormDialog.vue
+++ b/frontend/src/components/entities/EntityFormDialog.vue
@@ -492,7 +492,7 @@
               </v-window-item>
 
               <v-window-item value="append">
-                <append-editor v-model="formData.advanced.append" />
+                <append-editor v-model="formData.advanced.append" :available-entities="availableSourceEntities" />
               </v-window-item>
 
               <v-window-item value="extra_columns">


### PR DESCRIPTION
- Enhanced AppendConfig model to support entity-based append
- Added "From Entity" option to Append Editor component
- Implemented entity selector with column alignment options
- Added column mapping UI with align-by-position toggle
- Passed availableSourceEntities prop to AppendEditor

Previously, users could only configure fixed values or SQL query append types via the UI. Entity-based append (via `source:` field) required manual YAML editing despite core system support.

The Append Editor now supports all three append strategies:
1. Fixed Values - Hardcoded rows
2. SQL Query - SQL results
3. From Entity - Rows from another entity (NEW)

This enables users to configure entity-based row concatenation entirely through the UI, consistent with existing patterns.

Closes #281