### PR TITLE
Add sims client

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1110,6 +1110,9 @@ export const useExampleStore = defineStore('example', () => {
 - `backend/app/main.py` - FastAPI application entry point
 - `backend/app/services/validation_service.py` - Multi-type validation
 - `backend/app/services/shapeshift_service.py` - Entity preview with 3-tier cache
+- `backend/app/clients/reconciliation_client.py` - OpenRefine reconciliation HTTP client
+- `backend/app/clients/sims_client.py` - SIMS identity HTTP client (wraps `/identity` endpoints of sead_authority_service)
+- `backend/app/models/sims.py` - Client-side Pydantic DTOs for SIMS API
 - `backend/app/ingesters/protocol.py` - Ingester interface definition
 - `backend/app/ingesters/registry.py` - Dynamic ingester discovery system
 - `ingesters/sead/` - SEAD Clearinghouse ingester implementation
@@ -1185,3 +1188,20 @@ See `ingesters/README.md` for detailed guide. Basic steps:
 - **UCanAccess**: MS Access via JDBC (install: `scripts/install-uncanccess.sh`)
 - **Java JRE**: Required for UCanAccess
 - **pnpm**: Frontend package manager
+
+## SIMS Client (`backend/app/clients/sims_client.py`)
+
+`SimsClient` is an async `httpx` client that wraps the six `/identity` endpoints of `sead_authority_service`.
+DTOs are defined in `backend/app/models/sims.py` (client-side Pydantic models mirroring the authority service contracts).
+
+**Configuration**: `SHAPE_SHIFTER_SIMS_SERVICE_URL` env var (default `http://localhost:8000`) — exposed as `Settings.SIMS_SERVICE_URL` in `backend/app/core/config.py`.
+
+**Methods**:
+- `resolve(request)` → `ResolveResponse` — POST `/identity/resolve`
+- `get_binding_set(uuid)` → `BindingSetResponse` — GET `/identity/binding-sets/{uuid}`
+- `confirm_binding_set(uuid)` → `BindingSetResponse` — POST `/identity/binding-sets/{uuid}/confirm`
+- `associate_change_request(uuid, name)` → `BindingSetResponse` — POST `/identity/binding-sets/{uuid}/change-request`
+- `detect_change(request)` → `ChangeDetectionResult` — POST `/identity/detect-change`
+- `list_scopes()` → `list[SourceScope]` — GET `/identity/scopes`
+
+**Pattern**: same lazy-singleton `httpx.AsyncClient` as `ReconciliationClient`; call `await client.close()` in teardown.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -395,3 +395,20 @@ Then use with `--config ingest_config.json`. CLI options override config file va
 - Install UCanAccess via `scripts/install-uncanccess.sh` when Access support is required.
 - Ensure Java JRE is available for UCanAccess integrations.
 - Use `pnpm` as the frontend package manager whenever Node dependencies are involved.
+
+## SIMS Client (`backend/app/clients/sims_client.py`)
+
+`SimsClient` is an async `httpx` client that wraps the six `/identity` endpoints of `sead_authority_service`.
+DTOs are defined in `backend/app/models/sims.py` (client-side Pydantic models mirroring the authority service contracts).
+
+**Configuration**: `SHAPE_SHIFTER_SIMS_SERVICE_URL` env var (default `http://localhost:8000`) — set in `backend/app/core/config.py` as `Settings.SIMS_SERVICE_URL`.
+
+**Methods**:
+- `resolve(request)` → `ResolveResponse` — POST `/identity/resolve`
+- `get_binding_set(uuid)` → `BindingSetResponse` — GET `/identity/binding-sets/{uuid}`
+- `confirm_binding_set(uuid)` → `BindingSetResponse` — POST `/identity/binding-sets/{uuid}/confirm`
+- `associate_change_request(uuid, name)` → `BindingSetResponse` — POST `/identity/binding-sets/{uuid}/change-request`
+- `detect_change(request)` → `ChangeDetectionResult` — POST `/identity/detect-change`
+- `list_scopes()` → `list[SourceScope]` — GET `/identity/scopes`
+
+**Pattern**: same lazy-singleton `httpx.AsyncClient` as `ReconciliationClient`; call `await client.close()` in teardown.

--- a/TODO.md
+++ b/TODO.md
@@ -21,7 +21,6 @@
 ### New features
 
  - [] TODO: [Frontend/Backend] Edit data source configuration in a dual-mode editor (Form/YAML).
- - [] TODO: Add additional frontend/backend options (e.g., themes, temp directory, logging level, etc.)
  - [] TODO: Add capability to generate a default reconciliation YAML based on service manifest received from calling services /reconcile endpoint.
  - [] TODO: #68 Add a "finally" step that removes intermediate tables and columns.
  - [] TODO: #66 Introduce a "transformations" section with more advance columnar transforms (e.g. toWSG84).

--- a/backend/app/clients/__init__.py
+++ b/backend/app/clients/__init__.py
@@ -4,5 +4,6 @@ from backend.app.clients.reconciliation_client import (
     ReconciliationClient,
     ReconciliationQuery,
 )
+from backend.app.clients.sims_client import SimsClient
 
-__all__ = ["ReconciliationClient", "ReconciliationQuery"]
+__all__ = ["ReconciliationClient", "ReconciliationQuery", "SimsClient"]

--- a/backend/app/clients/sims_client.py
+++ b/backend/app/clients/sims_client.py
@@ -1,0 +1,186 @@
+"""HTTP client for the SIMS (SEAD Identity Management System) API.
+
+Wraps the six /identity endpoints exposed by sead_authority_service:
+
+  POST   /identity/resolve                                         Resolve + bind a batch
+  GET    /identity/binding-sets/{uuid}                             Get binding set status
+  POST   /identity/binding-sets/{uuid}/confirm                     Confirm a proposed binding set
+  POST   /identity/binding-sets/{uuid}/change-request              Associate a Sqitch CR name
+  POST   /identity/detect-change                                   Content-hash change detection
+  GET    /identity/scopes                                          List known source scopes
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import httpx
+from loguru import logger
+
+from backend.app.models.sims import (
+    BindingSetResponse,
+    ChangeDetectionRequest,
+    ChangeDetectionResult,
+    ResolveRequest,
+    ResolveResponse,
+    SourceScope,
+)
+
+
+class SimsClient:
+    """Async HTTP client for the SIMS identity service."""
+
+    def __init__(self, base_url: str, timeout: float = 30.0):
+        """
+        Initialise SIMS client.
+
+        Args:
+            base_url: Base URL of sead_authority_service, e.g. 'http://localhost:8000'.
+                      The client appends '/identity/...' paths automatically.
+            timeout:  Request timeout in seconds.
+        """
+        self.base_url: str = base_url.rstrip("/")
+        self.timeout: float = timeout
+        self._client: httpx.AsyncClient | None = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        """Return the shared httpx client, creating it on first use."""
+        if self._client is None:
+            logger.debug(f"[SIMS] Creating httpx.AsyncClient timeout={self.timeout}s base={self.base_url}")
+            self._client = httpx.AsyncClient(timeout=self.timeout)
+        return self._client
+
+    async def close(self) -> None:
+        """Close the underlying HTTP connection pool."""
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _url(self, path: str) -> str:
+        return f"{self.base_url}/identity/{path.lstrip('/')}"
+
+    async def _post(self, path: str, body: dict) -> dict:
+        client = await self._get_client()
+        url = self._url(path)
+        logger.debug(f"[SIMS] POST {url}")
+        response = await client.post(url, json=body)
+        response.raise_for_status()
+        return response.json()
+
+    async def _get(self, path: str) -> dict | list:
+        client = await self._get_client()
+        url = self._url(path)
+        logger.debug(f"[SIMS] GET {url}")
+        response = await client.get(url)
+        response.raise_for_status()
+        return response.json()
+
+    # ------------------------------------------------------------------
+    # Public API — mirrors sead_authority_service /identity endpoints
+    # ------------------------------------------------------------------
+
+    async def resolve(self, request: ResolveRequest) -> ResolveResponse:
+        """Resolve and bind a batch of source identities (POST /identity/resolve).
+
+        Idempotent: repeating the same request for the same scope produces the same
+        Source Identity records and, if already bound, the same Tracked Identity UUIDs.
+
+        Args:
+            request: Batch resolve request containing scope, submission name, and per-entity signals.
+
+        Returns:
+            ResolveResponse with submission UUID, scope UUID, binding set, and per-entity outcomes.
+
+        Raises:
+            httpx.HTTPStatusError: On 4xx/5xx responses from the authority service.
+        """
+        data = await self._post("resolve", request.model_dump(mode="json"))
+        return ResolveResponse.model_validate(data)
+
+    async def get_binding_set(self, binding_set_uuid: UUID) -> BindingSetResponse:
+        """Fetch the current state of a Binding Set (GET /identity/binding-sets/{uuid}).
+
+        Args:
+            binding_set_uuid: UUID returned by a previous :meth:`resolve` call.
+
+        Returns:
+            BindingSetResponse with lifecycle state and binding count.
+
+        Raises:
+            httpx.HTTPStatusError: 404 if the UUID is unknown.
+        """
+        data = await self._get(f"binding-sets/{binding_set_uuid}")
+        return BindingSetResponse.model_validate(data)
+
+    async def confirm_binding_set(self, binding_set_uuid: UUID) -> BindingSetResponse:
+        """Manually confirm a proposed Binding Set (POST /identity/binding-sets/{uuid}/confirm).
+
+        Applies to shared-metadata entities where ``auto_confirm`` is false.  Idempotent
+        for sets already in *confirmed* state.
+
+        Args:
+            binding_set_uuid: UUID of the Binding Set to confirm.
+
+        Returns:
+            Updated BindingSetResponse.
+
+        Raises:
+            httpx.HTTPStatusError: 404 if the UUID is unknown.
+        """
+        data = await self._post(f"binding-sets/{binding_set_uuid}/confirm", {})
+        return BindingSetResponse.model_validate(data)
+
+    async def associate_change_request(self, binding_set_uuid: UUID, change_request_name: str) -> BindingSetResponse:
+        """Link a Sqitch Change Request name to a confirmed Binding Set
+        (POST /identity/binding-sets/{uuid}/change-request).
+
+        Args:
+            binding_set_uuid:     UUID of the *confirmed* Binding Set.
+            change_request_name:  Sqitch change name, e.g. ``'deploy/2026-04/site-batch-1'``.
+
+        Returns:
+            Updated BindingSetResponse.
+
+        Raises:
+            httpx.HTTPStatusError: 404 if the UUID is unknown or set is not confirmed.
+        """
+        data = await self._post(
+            f"binding-sets/{binding_set_uuid}/change-request",
+            {"change_request_name": change_request_name},
+        )
+        return BindingSetResponse.model_validate(data)
+
+    async def detect_change(self, request: ChangeDetectionRequest) -> ChangeDetectionResult:
+        """Compare an incoming content hash against the stored hash for a Tracked Identity
+        (POST /identity/detect-change).
+
+        Returns ``insert`` (no prior hash), ``update`` (hash changed), or ``skip`` (hash unchanged).
+
+        Args:
+            request: Contains the ``tracked_identity_uuid`` and the new ``content_hash``.
+
+        Returns:
+            ChangeDetectionResult with outcome and the previously stored hash (if any).
+
+        Raises:
+            httpx.HTTPStatusError: 404 if the Tracked Identity UUID is unknown.
+        """
+        data = await self._post("detect-change", request.model_dump(mode="json"))
+        return ChangeDetectionResult.model_validate(data)
+
+    async def list_scopes(self) -> list[SourceScope]:
+        """Return all registered Source Scopes (GET /identity/scopes).
+
+        Returns:
+            List of SourceScope records known to the authority service.
+        """
+        data = await self._get("scopes")
+        return [SourceScope.model_validate(item) for item in data]

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -63,6 +63,7 @@ class Settings(BaseSettings):
 
     # Services
     RECONCILIATION_SERVICE_URL: str = "http://localhost:8000"
+    SIMS_SERVICE_URL: str = "http://localhost:8000"  # sead_authority_service base URL for /identity endpoints
 
     # Suggestions
     ENABLE_FK_SUGGESTIONS: bool = False

--- a/backend/app/models/sims.py
+++ b/backend/app/models/sims.py
@@ -1,0 +1,157 @@
+"""Pydantic models mirroring the SIMS (SEAD Identity Management System) API contracts.
+
+These are client-side DTOs for communicating with the sead_authority_service /identity endpoints.
+They mirror the models defined in sead_authority_service/src/identity/models.py and
+sead_authority_service/src/api/identity_router.py.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+# ---------------------------------------------------------------------------
+# Enumerations
+# ---------------------------------------------------------------------------
+
+
+class IdentityType(StrEnum):
+    """How a Source Identity value was obtained from the provider."""
+
+    UUID = "uuid"
+    BUSINESS_KEY = "business_key"
+    PROVIDER_KEY = "provider_key"
+    AUTHORITY_KEY = "authority_key"
+
+
+class BindingSetState(StrEnum):
+    """Lifecycle state of a Binding Set."""
+
+    PROPOSED = "proposed"
+    CONFIRMED = "confirmed"
+    REJECTED = "rejected"
+    SUPERSEDED = "superseded"
+    INVALIDATED = "invalidated"
+
+
+class BindingMethod(StrEnum):
+    """How a Binding was established between a Source Identity and a Tracked Identity."""
+
+    EXACT_MATCH = "exact_match"
+    BUSINESS_KEY = "business_key"
+    UUID_ACCEPTED = "uuid_accepted"
+    UUID_MAPPED = "uuid_mapped"
+    MANUAL = "manual"
+    ALLOCATED = "allocated"
+
+
+class ChangeOutcome(StrEnum):
+    """Result of a content-hash change detection comparison."""
+
+    INSERT = "insert"
+    UPDATE = "update"
+    SKIP = "skip"
+
+
+# ---------------------------------------------------------------------------
+# Request models (sent to SIMS)
+# ---------------------------------------------------------------------------
+
+
+class IdentitySignal(BaseModel):
+    """An identity signal submitted for resolution."""
+
+    identity_type: IdentityType = Field(description="Key type discriminator driving lookup strategy.")
+    identity_value: str = Field(description="Serialised key value, e.g. 'site_name=Nordic Site'.")
+    signals: dict | None = Field(
+        default=None,
+        description="Additional evidence: authority keys, alternative identifiers.",
+    )
+
+
+class ResolutionRequest(BaseModel):
+    """One domain entity submitted for identity resolution within a scope."""
+
+    entity_type: str = Field(description="SEAD entity type, e.g. 'site', 'taxa_tree_master'.")
+    primary_signal: IdentitySignal = Field(description="The main identity key used for idempotency lookup.")
+    additional_signals: list[IdentitySignal] = Field(
+        default_factory=list,
+        description="Optional supplementary keys also stored alongside the primary signal.",
+    )
+
+
+class ResolveRequest(BaseModel):
+    """Request body for POST /identity/resolve."""
+
+    scope_name: str = Field(description="Source Scope name, e.g. 'sead://reconciliation' or a provider URI.")
+    submission_name: str = Field(description="Human-readable name for this submission batch.")
+    requests: list[ResolutionRequest] = Field(
+        description="One entry per domain entity to resolve.",
+        min_length=1,
+    )
+    created_by: str | None = Field(default=None, description="Agent or user identifier for audit trail.")
+
+
+class ChangeDetectionRequest(BaseModel):
+    """Request body for POST /identity/detect-change."""
+
+    tracked_identity_uuid: UUID
+    content_hash: str = Field(description="Deterministic aggregate content hash computed by the submitting system.")
+
+
+# ---------------------------------------------------------------------------
+# Response models (received from SIMS)
+# ---------------------------------------------------------------------------
+
+
+class SourceScope(BaseModel):
+    """External namespace within which Source Identities are unique."""
+
+    scope_uuid: UUID
+    scope_name: str
+    parent_scope_uuid: UUID | None = None
+    description: str | None = None
+    created_at: datetime
+    created_by: str | None = None
+
+
+class ResolutionOutcome(BaseModel):
+    """Output of a single entity resolution within a POST /identity/resolve call."""
+
+    source_identity_uuid: UUID
+    entity_type: str
+    outcome: str = Field(description="'matched' or 'new'")
+    tracked_identity_uuid: UUID | None = None
+
+
+class BindingSetResponse(BaseModel):
+    """Represents a Binding Set and its current state."""
+
+    binding_set_uuid: UUID
+    submission_uuid: UUID | None = None
+    lifecycle_state: BindingSetState
+    change_request_name: str | None = None
+    binding_count: int = Field(description="Number of source↔tracked Binding rows within this set.")
+    created_at: datetime
+    confirmed_at: datetime | None = None
+
+
+class ResolveResponse(BaseModel):
+    """Response body for POST /identity/resolve."""
+
+    submission_uuid: UUID
+    scope_uuid: UUID
+    binding_set: BindingSetResponse
+    outcomes: list[ResolutionOutcome]
+
+
+class ChangeDetectionResult(BaseModel):
+    """Output of POST /identity/detect-change."""
+
+    tracked_identity_uuid: UUID
+    outcome: ChangeOutcome
+    previous_hash: str | None = Field(default=None, description="The previously stored hash, if any.")

--- a/frontend/src/views/ProjectDetailView.vue
+++ b/frontend/src/views/ProjectDetailView.vue
@@ -909,7 +909,7 @@
 
     <!-- Entity Editor Overlay (for graph double-click) -->
     <entity-form-dialog
-      v-if="entityStore.overlayEntityName && overlayEntity"
+      v-if="entityStore.overlayEntityName"
       v-model="entityStore.showEditorOverlay"
       :project-name="projectName"
       :entity="overlayEntity"


### PR DESCRIPTION
- Add backend/app/clients/sims_client.py: async httpx client wrapping all six /identity endpoints of sead_authority_service
- Add backend/app/models/sims.py: client-side Pydantic DTOs mirroring the SIMS API contracts (enums, request and response models)
- Add SIMS_SERVICE_URL setting (SHAPE_SHIFTER_SIMS_SERVICE_URL env var) to backend/app/core/config.py; defaults to http://localhost:8000
- Export SimsClient from backend/app/clients/__init__.py
- Update AGENTS.md and copilot-instructions.md to document the new client; fix stale SIMS stub references in authority service docs"