### PR TITLE
feat(frontend): add fixed entity column type editing

### DIFF
--- a/frontend/src/api/__tests__/entities.test.ts
+++ b/frontend/src/api/__tests__/entities.test.ts
@@ -13,6 +13,14 @@ vi.mock('../client', () => ({
 
 import { apiRequest } from '../client'
 
+function createEntityResponse(name: string, entityData: Record<string, unknown>): EntityResponse {
+  return {
+    name,
+    entity_data: entityData,
+    etag: `${name}-etag`,
+  }
+}
+
 describe('entitiesApi', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -21,8 +29,8 @@ describe('entitiesApi', () => {
   describe('list', () => {
     it('should fetch all entities for a project', async () => {
       const mockEntities: EntityResponse[] = [
-        { name: 'entity1', entity_data: { field: 'value1' } },
-        { name: 'entity2', entity_data: { field: 'value2' } },
+        createEntityResponse('entity1', { field: 'value1' }),
+        createEntityResponse('entity2', { field: 'value2' }),
       ]
 
       vi.mocked(apiRequest).mockResolvedValue(mockEntities)
@@ -47,10 +55,7 @@ describe('entitiesApi', () => {
 
   describe('get', () => {
     it('should fetch a specific entity', async () => {
-      const mockEntity: EntityResponse = {
-        name: 'test-entity',
-        entity_data: { table: 'users', columns: ['id', 'name'] },
-      }
+      const mockEntity: EntityResponse = createEntityResponse('test-entity', { table: 'users', columns: ['id', 'name'] })
 
       vi.mocked(apiRequest).mockResolvedValue(mockEntity)
 
@@ -64,10 +69,7 @@ describe('entitiesApi', () => {
     })
 
     it('should handle entity names with special characters', async () => {
-      const mockEntity: EntityResponse = {
-        name: 'entity-with-dash',
-        entity_data: {},
-      }
+      const mockEntity: EntityResponse = createEntityResponse('entity-with-dash', {})
 
       vi.mocked(apiRequest).mockResolvedValue(mockEntity)
 
@@ -90,10 +92,7 @@ describe('entitiesApi', () => {
         },
       }
 
-      const mockResponse: EntityResponse = {
-        name: 'new-entity',
-        entity_data: createRequest.entity_data,
-      }
+      const mockResponse: EntityResponse = createEntityResponse('new-entity', createRequest.entity_data)
 
       vi.mocked(apiRequest).mockResolvedValue(mockResponse)
 
@@ -113,10 +112,7 @@ describe('entitiesApi', () => {
         entity_data: {},
       }
 
-      vi.mocked(apiRequest).mockResolvedValue({
-        name: 'minimal-entity',
-        entity_data: {},
-      })
+      vi.mocked(apiRequest).mockResolvedValue(createEntityResponse('minimal-entity', {}))
 
       await entitiesApi.create('test-project', createRequest)
 
@@ -138,10 +134,7 @@ describe('entitiesApi', () => {
         },
       }
 
-      const mockResponse: EntityResponse = {
-        name: 'test-entity',
-        entity_data: updateRequest.entity_data,
-      }
+      const mockResponse: EntityResponse = createEntityResponse('test-entity', updateRequest.entity_data)
 
       vi.mocked(apiRequest).mockResolvedValue(mockResponse)
 
@@ -170,10 +163,7 @@ describe('entitiesApi', () => {
         },
       }
 
-      vi.mocked(apiRequest).mockResolvedValue({
-        name: 'orders',
-        entity_data: updateRequest.entity_data,
-      })
+      vi.mocked(apiRequest).mockResolvedValue(createEntityResponse('orders', updateRequest.entity_data))
 
       await entitiesApi.update('test-project', 'orders', updateRequest)
 

--- a/frontend/src/components/entities/EntityFormDialog.vue
+++ b/frontend/src/components/entities/EntityFormDialog.vue
@@ -532,6 +532,7 @@
                       <FixedValuesGrid
                         v-else-if="fixedValuesColumns.length > 0"
                         v-model="formData.values"
+                        v-model:column-types="formData.column_types"
                         :columns="fixedValuesColumns"
                         :public-id="formData.public_id"
                         height="400px"
@@ -1048,6 +1049,19 @@ const DEFAULT_DIALOG_WIDTH = 1100
 const DEFAULT_DIALOG_HEIGHT = 820
 const MIN_DIALOG_WIDTH = 900
 const MIN_DIALOG_HEIGHT = 640
+const SHOULD_DEBUG_ENTITY_FORM_DIALOG = import.meta.env.DEV && import.meta.env.MODE !== 'test'
+
+function debugEntityForm(...args: unknown[]): void {
+  if (SHOULD_DEBUG_ENTITY_FORM_DIALOG) {
+    console.debug(...args)
+  }
+}
+
+function warnEntityForm(...args: unknown[]): void {
+  if (SHOULD_DEBUG_ENTITY_FORM_DIALOG) {
+    console.warn(...args)
+  }
+}
 
 // Lazy load FixedValuesGrid to avoid ag-grid loading unless needed
 const FixedValuesGrid = defineAsyncComponent(() => import('./FixedValuesGrid.vue'))
@@ -1165,6 +1179,7 @@ interface FormData {
   surrogate_id: string // Deprecated - for backward compatibility
   keys: string[]
   columns: string[]
+  column_types: Record<string, string>
   values: any[][] // For fixed type entities
   source: string | null
   data_source: string
@@ -1198,6 +1213,28 @@ interface FormData {
   }
 }
 
+const SUPPORTED_FIXED_COLUMN_TYPES = new Set(['int', 'string', 'float', 'bool', 'date'])
+
+function normalizeFixedColumnTypes(value: unknown, allowedColumns: string[] = []): Record<string, string> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {}
+  }
+
+  const allowed = new Set(allowedColumns)
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>)
+      .map(([columnName, typeName]) => [columnName, String(typeName).trim().toLowerCase()] as const)
+      .filter(([columnName, typeName]) => {
+        if (!SUPPORTED_FIXED_COLUMN_TYPES.has(typeName)) {
+          return false
+        }
+
+        return allowed.size === 0 || allowed.has(columnName)
+      })
+  )
+}
+
 function normalizeChipField(value: unknown): string[] {
   if (Array.isArray(value)) {
     return value
@@ -1228,6 +1265,7 @@ const formData = ref<FormData>({
   surrogate_id: '', // Deprecated - kept for backward compat
   keys: [],
   columns: [],
+  column_types: {},
   values: [],
   source: null,
   data_source: '',
@@ -1725,6 +1763,11 @@ function buildEntityConfigFromFormData(options: BuildEntityConfigOptions = {}): 
 
   // Always include values field for fixed type (required by backend validation)
   if (formData.value.type === 'fixed') {
+    const normalizedColumnTypes = normalizeFixedColumnTypes(formData.value.column_types, fixedValuesColumns.value)
+    if (Object.keys(normalizedColumnTypes).length > 0) {
+      entityData.column_types = normalizedColumnTypes
+    }
+
     applyMaterializationRoundTripToFixedEntity(
       entityData,
       formData.value.values || [],
@@ -2051,7 +2094,7 @@ function hydrateColumnsFromSource() {
   const existing = formData.value.columns || []
   // Ensure saved selections stay visible even if source metadata is not yet available
   columnsOptions.value = Array.from(new Set([...existing, ...colsFromSource]))
-  console.debug('[EntityFormDialog] Hydrated columns from source:', {
+  debugEntityForm('[EntityFormDialog] Hydrated columns from source:', {
     source: formData.value.source,
     colsFromSource,
     existing,
@@ -2363,12 +2406,16 @@ watch(
 watch(
   () => fixedValuesColumns.value,
   (newColumns, oldColumns) => {
-    if (
-      suppressFixedSchemaRemap.value
-      || formData.value.type !== 'fixed'
-      || !Array.isArray(formData.value.values)
-      || oldColumns.length === 0
-    ) {
+    if (suppressFixedSchemaRemap.value || formData.value.type !== 'fixed') {
+      return
+    }
+
+    const normalizedColumnTypes = normalizeFixedColumnTypes(formData.value.column_types, newColumns)
+    if (JSON.stringify(normalizedColumnTypes) !== JSON.stringify(formData.value.column_types)) {
+      formData.value.column_types = normalizedColumnTypes
+    }
+
+    if (!Array.isArray(formData.value.values) || oldColumns.length === 0) {
       return
     }
 
@@ -2735,6 +2782,13 @@ function yamlToFormData(yamlString: string): boolean {
     const normalizedKeys = normalizeChipField(data.keys)
     const publicId = data.public_id || data.surrogate_id || ''
     const normalizedColumns = normalizeChipField(data.columns)
+    const editableFixedColumns = (data.type || 'entity') === 'fixed'
+      ? normalizeEditableFixedColumns(normalizedColumns, normalizedKeys, publicId)
+      : normalizedColumns
+    const fixedFullColumns = (data.type || 'entity') === 'fixed'
+      ? buildFixedValuesColumns(editableFixedColumns, normalizedKeys, publicId)
+      : normalizedColumns
+    const normalizedColumnTypes = normalizeFixedColumnTypes(data.column_types, fixedFullColumns)
 
     // Keep non-inline values/materialization metadata from YAML edits.
     const roundTrip = extractMaterializationRoundTripState(data)
@@ -2776,9 +2830,10 @@ function yamlToFormData(yamlString: string): boolean {
         public_id: publicId, // Migrate surrogate_id → public_id
         surrogate_id: data.surrogate_id || '', // Keep for backward compat
         keys: normalizedKeys,
+        column_types: normalizedColumnTypes,
         columns:
           (data.type || 'entity') === 'fixed'
-            ? normalizeEditableFixedColumns(normalizedColumns, normalizedKeys, publicId)
+            ? editableFixedColumns
             : normalizedColumns,
         values: normalizedFixedRows,
         source: data.source || null,
@@ -2952,7 +3007,7 @@ async function handleSubmit() {
           )
           // Update etag after successful save
           externalValuesEtag.value = response.etag
-          console.log('[EntityFormDialog] Saved external values')
+          debugEntityForm('[EntityFormDialog] Saved external values')
         } catch (err: any) {
           console.error('Failed to save external values:', err)
           // Check for conflict (409)
@@ -3027,7 +3082,7 @@ async function handleSubmitAndClose() {
           )
           // Update etag after successful save
           externalValuesEtag.value = response.etag
-          console.log('[EntityFormDialog] Saved external values (close)')
+          debugEntityForm('[EntityFormDialog] Saved external values (close)')
         } catch (err: any) {
           console.error('Failed to save external values:', err)
           // Check for conflict (409)
@@ -3141,7 +3196,7 @@ function handleUnmaterialized(unmaterializedEntities: string[]) {
 
   // Log unmaterialized entities
   if (unmaterializedEntities.length > 1) {
-    console.log(`Unmaterialized ${unmaterializedEntities.length} entities:`, unmaterializedEntities)
+    debugEntityForm(`Unmaterialized ${unmaterializedEntities.length} entities:`, unmaterializedEntities)
   }
 }
 
@@ -3165,10 +3220,15 @@ function buildFormDataFromEntity(entity: EntityResponse): FormData {
   const normalizedColumns = normalizeChipField(entity.entity_data.columns)
   const publicId = (entity.entity_data.public_id as string) || (entity.entity_data.surrogate_id as string) || ''
   let columns = normalizedColumns
+  let fixedFullColumns = normalizedColumns
   if (entity.entity_data.type === 'fixed') {
-    const fixedFullColumns = entity.fixed_schema?.full_columns || normalizedColumns
+    fixedFullColumns = entity.fixed_schema?.full_columns || normalizedColumns
     columns = normalizeEditableFixedColumns(fixedFullColumns, keys, publicId)
   }
+  const normalizedColumnTypes = normalizeFixedColumnTypes(
+    entity.entity_data.column_types,
+    entity.entity_data.type === 'fixed' ? fixedFullColumns : normalizedColumns
+  )
 
   // Handle values: can be either array (inline) or string (@load: directive for materialized entities)
   const roundTrip = extractMaterializationRoundTripState(entity.entity_data)
@@ -3195,6 +3255,7 @@ function buildFormDataFromEntity(entity: EntityResponse): FormData {
     public_id: publicId, // Migrate
     surrogate_id: (entity.entity_data.surrogate_id as string) || '', // Backward compat
     keys,
+    column_types: normalizedColumnTypes,
     columns: columns,
     values: normalizedFixedRows,
     source: (entity.entity_data.source as string) || null,
@@ -3243,7 +3304,7 @@ async function loadExternalValuesIfNeeded(entity: EntityResponse) {
     externalValuesError.value = null
 
     try {
-      console.log(`[EntityFormDialog] Loading external values for ${entity.name}: ${rawValues}`)
+      debugEntityForm(`[EntityFormDialog] Loading external values for ${entity.name}: ${rawValues}`)
       const response = await api.entities.getValues(props.projectName, entity.name)
 
       // Populate form data with fetched values
@@ -3262,7 +3323,7 @@ async function loadExternalValuesIfNeeded(entity: EntityResponse) {
       // Store etag for optimistic locking
       externalValuesEtag.value = response.etag
 
-      console.log(
+      debugEntityForm(
         `[EntityFormDialog] Loaded ${response.row_count} rows from external storage (${response.format}, etag: ${response.etag.substring(0, 8)}...)`
       )
     } catch (err) {
@@ -3296,6 +3357,7 @@ function buildDefaultFormData(): FormData {
     surrogate_id: '', // Backward compat
     keys: [],
     columns: [],
+    column_types: {},
     values: [],
     source: null,
     data_source: '',
@@ -3340,7 +3402,7 @@ watch(
     // - Create mode: always reset (no entity name required)
     // - Edit mode: reset when entity name is available
     if (isOpen && (mode === 'create' || entityName)) {
-      console.log('[EntityFormDialog] Dialog opening/entity changed, props:', {
+      debugEntityForm('[EntityFormDialog] Dialog opening/entity changed, props:', {
         mode: mode,
         entityName: entityName,
         hasEntity: !!props.entity,
@@ -3363,7 +3425,7 @@ watch(
         // Use entity from props (already fresh from reactive store)
         // Only fetch from API if props.entity is missing (defensive coding)
         if (props.entity) {
-          console.log('[EntityFormDialog] Using entity from props (reactive store):', entityName)
+          debugEntityForm('[EntityFormDialog] Using entity from props (reactive store):', entityName)
           currentEntity.value = props.entity
           suppressFixedSchemaRemap.value = true
           formData.value = buildFormDataFromEntity(props.entity)
@@ -3383,10 +3445,10 @@ watch(
         } else {
           // Fallback: fetch from API if entity not provided (shouldn't happen in normal flow)
           loading.value = true
-          console.warn('[EntityFormDialog] Entity not in props, fetching from API:', entityName)
+          warnEntityForm('[EntityFormDialog] Entity not in props, fetching from API:', entityName)
           try {
             const freshEntity = await api.entities.get(props.projectName, entityName)
-            console.log('[EntityFormDialog] API response received for:', freshEntity.name)
+            debugEntityForm('[EntityFormDialog] API response received for:', freshEntity.name)
             currentEntity.value = freshEntity
             suppressFixedSchemaRemap.value = true
             formData.value = buildFormDataFromEntity(freshEntity)
@@ -3524,17 +3586,17 @@ function handleAcceptForeignKey(fk: ForeignKeySuggestion) {
 
 function handleRejectForeignKey(fk: ForeignKeySuggestion) {
   // Just log for now - user rejected this suggestion
-  console.log('Rejected FK suggestion:', fk)
+  debugEntityForm('Rejected FK suggestion:', fk)
 }
 
 function handleAcceptDependency(dep: DependencySuggestion) {
   // Dependencies would be handled by the backend during processing
   // For now, just log
-  console.log('Accepted dependency suggestion:', dep)
+  debugEntityForm('Accepted dependency suggestion:', dep)
 }
 
 function handleRejectDependency(dep: DependencySuggestion) {
-  console.log('Rejected dependency suggestion:', dep)
+  debugEntityForm('Rejected dependency suggestion:', dep)
 }
 </script>
 

--- a/frontend/src/components/entities/FixedValuesGrid.vue
+++ b/frontend/src/components/entities/FixedValuesGrid.vue
@@ -11,8 +11,28 @@
       </div>
     </div>
 
-    <v-alert v-if="validationErrors.length > 0" type="error" variant="tonal" density="compact" class="mb-2">
-      <div v-for="error in validationErrors" :key="error" class="text-caption">{{ error }}</div>
+    <div v-if="props.columns.length > 0" class="column-type-controls mb-2">
+      <div v-for="columnName in props.columns" :key="columnName" class="column-type-control">
+        <span class="column-type-control__label">{{ columnName }}</span>
+        <span class="column-type-control__source">{{ getColumnTypeSourceLabel(columnName) }}</span>
+        <select
+          class="column-type-control__select"
+          :value="getColumnTypeSelectorValue(columnName)"
+          @change="onColumnTypeChange(columnName, $event)"
+        >
+          <option
+            v-for="option in getColumnTypeOptions(columnName)"
+            :key="`${columnName}-${option.value}`"
+            :value="option.value"
+          >
+            {{ option.label }}
+          </option>
+        </select>
+      </div>
+    </div>
+
+    <v-alert v-if="validationSummary.length > 0" type="error" variant="tonal" density="compact" class="mb-2">
+      <div v-for="error in validationSummary" :key="error" class="text-caption">{{ error }}</div>
     </v-alert>
 
     <ag-grid-vue class="ag-theme-alpine compact-grid" :style="{ height: gridHeight }" :columnDefs="columnDefs"
@@ -32,36 +52,50 @@ import {
   buildGridRowData,
   coerceGridRows,
   coerceGridValue,
+  type FixedGridColumnTypeName,
+  type GridValidationIssue,
   inferColumnType,
+  normalizeGridColumnTypes,
   parseClipboardTable,
+  summarizeValidationIssues,
 } from './fixedValuesGridClipboard'
 import 'ag-grid-community/styles/ag-grid.css'
 import 'ag-grid-community/styles/ag-theme-alpine.css'
 
+interface ColumnTypeOption {
+  value: 'auto' | FixedGridColumnTypeName
+  label: string
+}
+
 interface Props {
   modelValue: any[][]
   columns: string[]
+  columnTypes?: Record<string, string>
   publicId?: string
   height?: string
 }
 
 const props = withDefaults(defineProps<Props>(), {
   height: '300px',
+  columnTypes: () => ({}),
   publicId: undefined,
 })
 
 const emit = defineEmits<{
   'update:modelValue': [value: any[][]]
+  'update:columnTypes': [value: Record<string, string>]
   'validation-errors': [value: string[]]
 }>()
 
 const gridApi = ref<GridApi>()
 const hasSelection = ref(false)
 const lastEmittedModelSignature = ref<string | null>(null)
-const validationErrors = ref<string[]>([])
+const validationSummary = ref<string[]>([])
+const invalidCellMessages = ref<Record<string, string>>({})
 
 const gridHeight = computed(() => props.height)
 const systemIdColumnIndex = computed(() => props.columns.findIndex((col) => col === 'system_id'))
+const normalizedColumnTypes = computed<Record<string, FixedGridColumnTypeName>>(() => normalizeGridColumnTypes(props.columnTypes))
 
 const defaultColDef: ColDef = {
   editable: true,
@@ -72,22 +106,87 @@ const defaultColDef: ColDef = {
   flex: 1,
 }
 
-function setValidationErrors(errors: string[]) {
-  validationErrors.value = errors
-  emit('validation-errors', errors)
+function buildInvalidCellKey(rowIndex: number, columnName: string): string {
+  return `${rowIndex}:${columnName}`
 }
 
-function clearValidationErrors() {
-  if (validationErrors.value.length === 0) {
+function setValidationIssues(issues: GridValidationIssue[]) {
+  invalidCellMessages.value = Object.fromEntries(
+    issues.map((issue) => [buildInvalidCellKey(issue.rowIndex, issue.columnName), issue.message])
+  )
+
+  const summary = summarizeValidationIssues(issues)
+  validationSummary.value = summary
+  emit('validation-errors', summary)
+}
+
+function clearValidationIssues() {
+  if (validationSummary.value.length === 0 && Object.keys(invalidCellMessages.value).length === 0) {
     return
   }
 
-  validationErrors.value = []
+  validationSummary.value = []
+  invalidCellMessages.value = {}
   emit('validation-errors', [])
 }
 
-function formatValidationError(columnName: string, rowIndex: number, error: string): string {
-  return `Row ${rowIndex + 1}, column ${columnName}: ${error}`
+function hasValidationIssue(rowIndex: number, columnName: string): boolean {
+  return Boolean(invalidCellMessages.value[buildInvalidCellKey(rowIndex, columnName)])
+}
+
+function getValidationIssueMessage(rowIndex: number, columnName: string): string | undefined {
+  return invalidCellMessages.value[buildInvalidCellKey(rowIndex, columnName)]
+}
+
+function formatTypeLabel(typeName: FixedGridColumnTypeName): string {
+  if (typeName === 'int') {
+    return 'Integer'
+  }
+
+  return typeName.charAt(0).toUpperCase() + typeName.slice(1)
+}
+
+function getColumnTypeSelectorValue(columnName: string): 'auto' | FixedGridColumnTypeName {
+  return normalizedColumnTypes.value[columnName] || 'auto'
+}
+
+function getColumnTypeSourceLabel(columnName: string): string {
+  const explicitType = normalizedColumnTypes.value[columnName]
+
+  if (explicitType) {
+    return `Declared: ${explicitType}`
+  }
+
+  return `Inferred: ${inferColumnType(columnName) === 'number' ? 'int' : 'string'}`
+}
+
+function getColumnTypeOptions(columnName: string): ColumnTypeOption[] {
+  const currentType = normalizedColumnTypes.value[columnName]
+  const options: ColumnTypeOption[] = [
+    { value: 'auto', label: 'Auto' },
+    { value: 'int', label: 'Integer' },
+    { value: 'string', label: 'String' },
+  ]
+
+  if (currentType && !['int', 'string'].includes(currentType)) {
+    options.unshift({ value: currentType, label: `Preserve: ${formatTypeLabel(currentType)}` })
+  }
+
+  return options
+}
+
+function onColumnTypeChange(columnName: string, event: Event) {
+  const target = event.target as HTMLSelectElement | null
+  const nextValue = target?.value
+  const nextColumnTypes: Record<string, string> = { ...normalizedColumnTypes.value }
+
+  if (!nextValue || nextValue === 'auto') {
+    delete nextColumnTypes[columnName]
+  } else {
+    nextColumnTypes[columnName] = nextValue
+  }
+
+  emit('update:columnTypes', nextColumnTypes)
 }
 
 const columnDefs = computed<ColDef[]>(() => {
@@ -112,7 +211,6 @@ const columnDefs = computed<ColDef[]>(() => {
     ...props.columns.map((col, index) => {
       const isSystemId = col === 'system_id'
       const isPublicId = col === props.publicId
-      const isIntegerColumn = inferColumnType(col) === 'number'
 
       return {
         field: `col_${index}`,
@@ -124,23 +222,21 @@ const columnDefs = computed<ColDef[]>(() => {
         minWidth: 100,
         flex: 1,
         valueParser: isSystemId ? undefined : (params: any) => {
-          const result = coerceGridValue(col, params.newValue, params.oldValue)
+          const result = coerceGridValue(col, params.newValue, params.oldValue, props.columnTypes)
 
           if (result.error) {
-            setValidationErrors([
-              formatValidationError(col, params.node?.rowIndex ?? 0, result.error),
-            ])
+            setValidationIssues([{ rowIndex: params.node?.rowIndex ?? 0, columnName: col, message: result.error }])
             return params.oldValue
-          }
-
-          if (isIntegerColumn) {
-            clearValidationErrors()
           }
 
           return result.value
         },
         cellClass: isSystemId ? 'system-id-column' : (isPublicId ? 'public-id-column' : ''),
+        cellClassRules: {
+          'invalid-fixed-value-cell': (params: any) => hasValidationIssue(params.node?.rowIndex ?? -1, col),
+        },
         headerClass: isSystemId ? 'system-id-header' : (isPublicId ? 'public-id-header' : ''),
+        tooltipValueGetter: (params: any) => getValidationIssueMessage(params.node?.rowIndex ?? -1, col) || null,
       }
     }),
   ]
@@ -167,13 +263,13 @@ function serializeModelValue(rows: any[][]): string {
 }
 
 function emitModelValueUpdate(rows: any[][]) {
-  const coerced = coerceGridRows(props.columns, rows)
-  if (coerced.errors.length > 0) {
-    setValidationErrors(coerced.errors)
+  const coerced = coerceGridRows(props.columns, rows, props.columnTypes)
+  if (coerced.issues.length > 0) {
+    setValidationIssues(coerced.issues)
     return
   }
 
-  clearValidationErrors()
+  clearValidationIssues()
   lastEmittedModelSignature.value = serializeModelValue(coerced.rows)
   emit('update:modelValue', coerced.rows)
 }
@@ -341,6 +437,7 @@ function onPaste(event: ClipboardEvent) {
   const pasteResult = applyClipboardMatrix({
     rows: getAllRows(false),
     columns: props.columns,
+    columnTypes: props.columnTypes,
     startRowIndex,
     startColIndex,
     matrix,
@@ -350,10 +447,10 @@ function onPaste(event: ClipboardEvent) {
     },
   })
 
-  if (pasteResult.errors.length > 0) {
-    setValidationErrors(pasteResult.errors)
+  if (pasteResult.issues.length > 0) {
+    setValidationIssues(pasteResult.issues)
   } else {
-    clearValidationErrors()
+    clearValidationIssues()
   }
 
   gridApi.value.setGridOption('rowData', buildGridRowData(pasteResult.rows, systemIdColumnIndex.value))
@@ -361,8 +458,8 @@ function onPaste(event: ClipboardEvent) {
 }
 
 watch(
-  () => props.modelValue,
-  (newValue) => {
+  [() => props.modelValue, () => props.columnTypes],
+  ([newValue]) => {
     const incomingRows = newValue || []
     const incomingSignature = serializeModelValue(incomingRows)
 
@@ -370,15 +467,17 @@ watch(
       return
     }
 
-    const coerced = coerceGridRows(props.columns, incomingRows)
+    const coerced = coerceGridRows(props.columns, incomingRows, props.columnTypes)
     const coercedSignature = serializeModelValue(coerced.rows)
 
-    if (coerced.errors.length > 0) {
-      setValidationErrors(coerced.errors)
+    if (coerced.issues.length > 0) {
+      setValidationIssues(coerced.issues)
     } else if (coercedSignature !== incomingSignature) {
-      clearValidationErrors()
+      clearValidationIssues()
       emitModelValueUpdate(incomingRows)
       return
+    } else {
+      clearValidationIssues()
     }
 
     if (gridApi.value) {
@@ -392,6 +491,43 @@ watch(
 <style scoped>
 .fixed-values-grid {
   width: 100%;
+}
+
+.column-type-controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 8px;
+}
+
+.column-type-control {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px;
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.12);
+  border-radius: 4px;
+  background: rgba(var(--v-theme-surface), 0.45);
+}
+
+.column-type-control__label {
+  font-size: 11px;
+  font-weight: 600;
+  color: rgb(var(--v-theme-on-surface));
+}
+
+.column-type-control__source {
+  font-size: 10px;
+  color: rgba(var(--v-theme-on-surface), 0.68);
+}
+
+.column-type-control__select {
+  min-height: 28px;
+  padding: 4px 8px;
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.18);
+  border-radius: 4px;
+  background: rgb(var(--v-theme-background));
+  color: rgb(var(--v-theme-on-background));
+  font-size: 11px;
 }
 
 .compact-grid {
@@ -477,5 +613,10 @@ watch(
   background: rgba(var(--v-theme-primary), 0.1) !important;
   font-weight: 700;
   color: rgb(var(--v-theme-primary)) !important;
+}
+
+.compact-grid :deep(.invalid-fixed-value-cell) {
+  background: rgba(var(--v-theme-error), 0.12) !important;
+  box-shadow: inset 0 0 0 1px rgba(var(--v-theme-error), 0.35);
 }
 </style>

--- a/frontend/src/components/entities/__tests__/EntityFormDialog.test.ts
+++ b/frontend/src/components/entities/__tests__/EntityFormDialog.test.ts
@@ -84,6 +84,9 @@ vi.mock('@/api', () => ({
       getValues: mockState.getValues,
       updateValues: mockState.updateValues,
     },
+    dataSources: {
+      getEntityTypes: vi.fn(async () => []),
+    },
     excelMetadata: {
       fetch: vi.fn(async () => ({ sheets: [], columns: [] })),
     },
@@ -152,6 +155,11 @@ const childStubs = {
   BranchEditor: { template: '<div data-testid="branch-editor" />' },
   ExtraColumnsEditor: { template: '<div data-testid="extra-columns-editor" />' },
   ReplacementsEditor: { template: '<div data-testid="replacements-editor" />' },
+  FixedValuesGrid: {
+    name: 'FixedValuesGrid',
+    props: ['modelValue', 'columns', 'publicId', 'columnTypes'],
+    template: '<div data-testid="fixed-values-grid" />',
+  },
   SuggestionsPanel: { template: '<div data-testid="suggestions-panel" />' },
   MaterializeDialog: { template: '<div data-testid="materialize-dialog" />' },
   UnmaterializeDialog: { template: '<div data-testid="unmaterialize-dialog" />' },
@@ -176,6 +184,29 @@ const mergedEntity = createEntity('analysis_entity', {
     { name: 'relative_dating', source: 'relative_dating_source', keys: ['sample_name'] },
   ],
 })
+
+const fixedEntity: EntityResponse = {
+  name: 'method',
+  etag: 'etag-method',
+  fixed_schema: {
+    full_columns: ['system_id', 'method_id', 'label', 'created_at'],
+    editable_columns: ['label', 'created_at'],
+    identity_columns: ['system_id', 'method_id'],
+    key_columns: ['label'],
+    order_source: 'stored',
+  },
+  entity_data: {
+    type: 'fixed',
+    public_id: 'method_id',
+    keys: ['label'],
+    columns: ['system_id', 'method_id', 'label', 'created_at'],
+    column_types: {
+      label: 'string',
+      created_at: 'date',
+    },
+    values: [[1, 53, 'Sampling', '2026-05-19']],
+  },
+}
 
 const sourceEntities = [
   createEntity('abundance_source', {
@@ -219,6 +250,8 @@ function findTabByValue(wrapper: ReturnType<typeof mountEntityFormDialog>, value
 describe('EntityFormDialog', () => {
   beforeEach(() => {
     mockState.entities = [...sourceEntities]
+    mockState.create.mockResolvedValue(undefined)
+    mockState.update.mockResolvedValue(undefined)
     mockState.previewData = {
       entity_name: 'analysis_entity',
       rows: [
@@ -333,5 +366,45 @@ describe('EntityFormDialog', () => {
     expect(mockState.previewEntity).toHaveBeenCalledWith('arbodat', 'abundance_source', 100)
     expect(wrapper.text()).toContain('Previewing source rows for abundance')
     expect(wrapper.text()).toContain('abundance_source')
+  })
+
+  it('loads fixed entity column_types into the grid and persists updates on save', async () => {
+    const wrapper = mountEntityFormDialog({
+      mode: 'edit',
+      entity: fixedEntity,
+    })
+
+    await flushPromises()
+    await nextTick()
+
+    const fixedValuesGrid = wrapper.findComponent({ name: 'FixedValuesGrid' })
+    expect(fixedValuesGrid.exists()).toBe(true)
+    expect(fixedValuesGrid.props('columnTypes')).toEqual({
+      label: 'string',
+      created_at: 'date',
+    })
+
+    fixedValuesGrid.vm.$emit('update:columnTypes', {
+      label: 'int',
+      created_at: 'date',
+    })
+
+    await flushPromises()
+    await nextTick()
+
+    const saveButton = wrapper.findAll('button').find((button) => button.text().trim() === 'Save')
+    expect(saveButton).toBeTruthy()
+
+    await saveButton!.trigger('click')
+    await flushPromises()
+
+    expect(mockState.update).toHaveBeenCalledWith('method', {
+      entity_data: expect.objectContaining({
+        column_types: {
+          label: 'int',
+          created_at: 'date',
+        },
+      }),
+    })
   })
 })

--- a/frontend/src/components/entities/__tests__/EntityListCard.test.ts
+++ b/frontend/src/components/entities/__tests__/EntityListCard.test.ts
@@ -29,11 +29,31 @@ const DeleteConfirmationDialogStub = {
   template: '<div class="delete-confirmation-dialog-stub" />',
 }
 
+const VTextFieldStub = {
+  name: 'VTextField',
+  props: ['modelValue', 'prependInnerIcon', 'label', 'variant', 'density', 'clearable', 'hideDetails', 'prefix'],
+  template: '<div class="v-text-field-stub" />',
+}
+
+const VSelectStub = {
+  name: 'VSelect',
+  props: ['modelValue', 'items', 'label', 'variant', 'density', 'clearable', 'hideDetails', 'prefix'],
+  template: '<div class="v-select-stub" />',
+}
+
+const globalStubs = {
+  EntityFormDialog: EntityFormDialogStub,
+  DeleteConfirmationDialog: DeleteConfirmationDialogStub,
+  VTextField: VTextFieldStub,
+  VSelect: VSelectStub,
+}
+
 function createEntity(name: string): EntityResponse {
   return {
     name,
     entity_data: { type: 'entity' },
-  } as EntityResponse
+    etag: `${name}-etag`,
+  }
 }
 
 describe('EntityListCard', () => {
@@ -54,10 +74,7 @@ describe('EntityListCard', () => {
       },
       global: {
         renderStubDefaultSlot: true,
-        stubs: {
-          EntityFormDialog: EntityFormDialogStub,
-          DeleteConfirmationDialog: DeleteConfirmationDialogStub,
-        },
+        stubs: globalStubs,
       },
     })
 
@@ -77,10 +94,7 @@ describe('EntityListCard', () => {
       },
       global: {
         renderStubDefaultSlot: true,
-        stubs: {
-          EntityFormDialog: EntityFormDialogStub,
-          DeleteConfirmationDialog: DeleteConfirmationDialogStub,
-        },
+        stubs: globalStubs,
       },
     })
 
@@ -107,10 +121,7 @@ describe('EntityListCard', () => {
       },
       global: {
         renderStubDefaultSlot: true,
-        stubs: {
-          EntityFormDialog: EntityFormDialogStub,
-          DeleteConfirmationDialog: DeleteConfirmationDialogStub,
-        },
+        stubs: globalStubs,
       },
     })
 

--- a/frontend/src/components/entities/__tests__/FixedValuesGrid.test.ts
+++ b/frontend/src/components/entities/__tests__/FixedValuesGrid.test.ts
@@ -15,6 +15,7 @@ describe('FixedValuesGrid', () => {
       props: {
         modelValue: [[1, '53', 'Sampling']],
         columns: ['system_id', 'method_id', 'name'],
+        columnTypes: {},
         publicId: 'method_id',
       },
       global: {
@@ -37,6 +38,7 @@ describe('FixedValuesGrid', () => {
       props: {
         modelValue: [[1, '53abc', 'Sampling']],
         columns: ['system_id', 'method_id', 'name'],
+        columnTypes: {},
         publicId: 'method_id',
       },
       global: {
@@ -50,7 +52,49 @@ describe('FixedValuesGrid', () => {
 
     expect(wrapper.emitted('update:modelValue')).toBeUndefined()
     expect(wrapper.emitted('validation-errors')).toEqual([
-      [['Row 1, column method_id: Expected integer ID']],
+      [['Column method_id: 1 invalid value (row 1)']],
     ])
+  })
+
+  it('uses declared int column types for non-_id columns', async () => {
+    const wrapper = shallowMount(FixedValuesGrid, {
+      props: {
+        modelValue: [[1, '7', 'Sampling']],
+        columns: ['system_id', 'rank', 'name'],
+        columnTypes: { rank: 'int' },
+        publicId: 'name',
+      },
+      global: {
+        stubs: {
+          AgGridVue: AgGridVueStub,
+        },
+      },
+    })
+
+    await nextTick()
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([
+      [[[1, 7, 'Sampling']]],
+    ])
+  })
+
+  it('does not coerce unsupported declared types on load', async () => {
+    const wrapper = shallowMount(FixedValuesGrid, {
+      props: {
+        modelValue: [[1, true]],
+        columns: ['system_id', 'is_active'],
+        columnTypes: { is_active: 'bool' },
+      },
+      global: {
+        stubs: {
+          AgGridVue: AgGridVueStub,
+        },
+      },
+    })
+
+    await nextTick()
+
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+    expect(wrapper.emitted('validation-errors')).toBeUndefined()
   })
 })

--- a/frontend/src/components/entities/__tests__/fixedValuesGridClipboard.test.ts
+++ b/frontend/src/components/entities/__tests__/fixedValuesGridClipboard.test.ts
@@ -6,8 +6,10 @@ import {
   coerceGridRows,
   coerceGridValue,
   inferColumnType,
+  normalizeGridColumnTypes,
   parseClipboardTable,
   parseStrictInteger,
+  summarizeValidationIssues,
 } from '../fixedValuesGridClipboard'
 
 describe('fixedValuesGridClipboard', () => {
@@ -55,6 +57,12 @@ describe('fixedValuesGridClipboard', () => {
     expect(inferColumnType('label')).toBe('string')
   })
 
+  it('uses explicit fixed column types ahead of naming inference', () => {
+    expect(inferColumnType('rank', { rank: 'int' })).toBe('number')
+    expect(inferColumnType('label', { label: 'string' })).toBe('string')
+    expect(inferColumnType('created_at', { created_at: 'date' })).toBe('preserve')
+  })
+
   it('parses strict integers without truncation', () => {
     expect(parseStrictInteger('53')).toBe(53)
     expect(parseStrictInteger('-7')).toBe(-7)
@@ -90,9 +98,33 @@ describe('fixedValuesGridClipboard', () => {
     })
   })
 
+  it('coerces declared int columns even when the name does not end with _id', () => {
+    expect(coerceGridValue('rank', '7', null, { rank: 'int' })).toEqual({
+      value: 7,
+      error: null,
+    })
+    expect(coerceGridValue('rank', '7x', 3, { rank: 'int' })).toEqual({
+      value: 3,
+      error: 'Expected integer value',
+    })
+  })
+
+  it('preserves unsupported-yet declared types without coercing loaded scalar values', () => {
+    expect(coerceGridValue('created_at', '2026-05-19', null, { created_at: 'date' })).toEqual({
+      value: '2026-05-19',
+      error: null,
+    })
+    expect(coerceGridRows(['system_id', 'is_active'], [[1, true]], { is_active: 'bool' })).toEqual({
+      rows: [[1, true]],
+      issues: [],
+      errors: [],
+    })
+  })
+
   it('coerces loaded rows so save can persist normalized integer ids', () => {
     expect(coerceGridRows(['system_id', 'method_group_id', 'label'], [[1, '53', 'Method A']])).toEqual({
       rows: [[1, 53, 'Method A']],
+      issues: [],
       errors: [],
     })
   })
@@ -100,7 +132,24 @@ describe('fixedValuesGridClipboard', () => {
   it('collects row errors when loaded values contain invalid integer ids', () => {
     expect(coerceGridRows(['system_id', 'method_group_id', 'label'], [[1, '53abc', 'Method A']])).toEqual({
       rows: [[1, '53abc', 'Method A']],
+      issues: [{ rowIndex: 0, columnName: 'method_group_id', message: 'Expected integer ID' }],
       errors: ['Row 1, column method_group_id: Expected integer ID'],
+    })
+  })
+
+  it('summarizes validation issues per column', () => {
+    expect(summarizeValidationIssues([
+      { rowIndex: 0, columnName: 'rank', message: 'Expected integer value' },
+      { rowIndex: 2, columnName: 'rank', message: 'Expected integer value' },
+    ])).toEqual([
+      'Column rank: 2 invalid values (rows 1, 3)',
+    ])
+  })
+
+  it('normalizes only supported fixed column types', () => {
+    expect(normalizeGridColumnTypes({ rank: 'INT', label: 'string', skip: 'json' })).toEqual({
+      rank: 'int',
+      label: 'string',
     })
   })
 })

--- a/frontend/src/components/entities/entityFormMaterialization.ts
+++ b/frontend/src/components/entities/entityFormMaterialization.ts
@@ -11,7 +11,7 @@ export interface MaterializationRoundTripState {
  */
 export function normalizeEditableFixedColumns(
   columns: string[],
-  keys: string[],
+  _keys: string[],
   publicId: string | null | undefined
 ): string[] {
   const hiddenColumns = new Set<string>(['system_id'])

--- a/frontend/src/components/entities/fixedValuesGridClipboard.ts
+++ b/frontend/src/components/entities/fixedValuesGridClipboard.ts
@@ -1,28 +1,90 @@
-export type GridColumnType = 'number' | 'string'
-
+export type FixedGridColumnTypeName = 'int' | 'string' | 'float' | 'bool' | 'date'
+export type GridColumnType = 'number' | 'string' | 'preserve'
+export interface GridValidationIssue {
+  rowIndex: number
+  columnName: string
+  message: string
+}
 export interface CoercedGridValue {
   value: any
   error: string | null
 }
-
 export interface ApplyClipboardMatrixResult {
   rows: any[][]
+  issues: GridValidationIssue[]
   errors: string[]
 }
-
 export interface CoerceGridRowsResult {
   rows: any[][]
+  issues: GridValidationIssue[]
   errors: string[]
 }
+const ALL_FIXED_GRID_COLUMN_TYPES: FixedGridColumnTypeName[] = ['int', 'string', 'float', 'bool', 'date']
 
-export function inferColumnType(columnName: string): GridColumnType {
+function isFixedGridColumnTypeName(value: string): value is FixedGridColumnTypeName {
+  return ALL_FIXED_GRID_COLUMN_TYPES.includes(value as FixedGridColumnTypeName)
+}
+export function normalizeGridColumnTypes(columnTypes?: Record<string, unknown> | null): Record<string, FixedGridColumnTypeName> {
+  if (!columnTypes) {
+    return {}
+  }
+
+  return Object.fromEntries(
+    Object.entries(columnTypes)
+      .map(([columnName, typeName]) => [columnName, String(typeName).trim().toLowerCase()] as const)
+      .filter((entry): entry is [string, FixedGridColumnTypeName] => isFixedGridColumnTypeName(entry[1]))
+  )
+}
+function getIntegerValidationMessage(columnName: string, explicitType: FixedGridColumnTypeName | undefined): string {
+  if (explicitType === 'int' && !columnName.endsWith('_id')) {
+    return 'Expected integer value'
+  }
+
+  return 'Expected integer ID'
+}
+export function formatValidationIssue(issue: GridValidationIssue): string {
+  return `Row ${issue.rowIndex + 1}, column ${issue.columnName}: ${issue.message}`
+}
+
+export function summarizeValidationIssues(issues: GridValidationIssue[]): string[] {
+  const issuesByColumn = new Map<string, GridValidationIssue[]>()
+
+  for (const issue of issues) {
+    const columnIssues = issuesByColumn.get(issue.columnName) || []
+    columnIssues.push(issue)
+    issuesByColumn.set(issue.columnName, columnIssues)
+  }
+
+  return Array.from(issuesByColumn.entries()).map(([columnName, columnIssues]) => {
+    const rowNumbers = Array.from(new Set(columnIssues.map((issue) => issue.rowIndex + 1))).sort((left, right) => left - right)
+    const valueLabel = columnIssues.length === 1 ? 'value' : 'values'
+    const rowLabel = rowNumbers.length === 1 ? 'row' : 'rows'
+
+    return `Column ${columnName}: ${columnIssues.length} invalid ${valueLabel} (${rowLabel} ${rowNumbers.join(', ')})`
+  })
+}
+export function inferColumnType(columnName: string, columnTypes?: Record<string, unknown> | null): GridColumnType {
+  const normalizedColumnTypes = normalizeGridColumnTypes(columnTypes)
+  const explicitType = normalizedColumnTypes[columnName]
+
+  if (explicitType === 'int') {
+    return 'number'
+  }
+
+  if (explicitType === 'string') {
+    return 'string'
+  }
+
+  if (explicitType) {
+    return 'preserve'
+  }
+
   if (columnName.endsWith('_id')) {
     return 'number'
   }
 
   return 'string'
 }
-
 export function parseStrictInteger(value: unknown): number | null {
   if (value === null || value === undefined) {
     return null
@@ -39,21 +101,43 @@ export function parseStrictInteger(value: unknown): number | null {
 
   return Number(text)
 }
+export function coerceGridValue(
+  columnName: string,
+  value: unknown,
+  fallbackValue: any = null,
+  columnTypes?: Record<string, unknown> | null,
+): CoercedGridValue {
+  const normalizedColumnTypes = normalizeGridColumnTypes(columnTypes)
+  const explicitType = normalizedColumnTypes[columnName]
+  const inferredType = inferColumnType(columnName, normalizedColumnTypes)
 
-export function coerceGridValue(columnName: string, value: unknown, fallbackValue: any = null): CoercedGridValue {
-  if (inferColumnType(columnName) === 'number') {
+  if (inferredType === 'number') {
     const parsed = parseStrictInteger(value)
     const text = value === null || value === undefined ? '' : String(value).trim()
 
     if (parsed === null && text !== '') {
       return {
         value: fallbackValue,
-        error: 'Expected integer ID',
+        error: getIntegerValidationMessage(columnName, explicitType),
       }
     }
 
     return {
       value: parsed,
+      error: null,
+    }
+  }
+
+  if (inferredType === 'preserve') {
+    if (value === null || value === undefined || value === '') {
+      return {
+        value: null,
+        error: null,
+      }
+    }
+
+    return {
+      value,
       error: null,
     }
   }
@@ -70,7 +154,6 @@ export function coerceGridValue(columnName: string, value: unknown, fallbackValu
     error: null,
   }
 }
-
 export function parseClipboardTable(text: string): string[][] {
   const rows = text
     .replace(/\r\n/g, '\n')
@@ -84,7 +167,6 @@ export function parseClipboardTable(text: string): string[][] {
 
   return rows
 }
-
 export function buildGridRowData(rows: any[][], systemIdColumnIndex: number): Array<Record<string, any>> {
   return rows.map((row, rowIndex) => {
     const stableSystemId = systemIdColumnIndex >= 0 ? row[systemIdColumnIndex] : undefined
@@ -99,45 +181,48 @@ export function buildGridRowData(rows: any[][], systemIdColumnIndex: number): Ar
     return rowObj
   })
 }
-
-export function coerceGridRows(columns: string[], rows: any[][]): CoerceGridRowsResult {
-  const errors: string[] = []
+export function coerceGridRows(
+  columns: string[],
+  rows: any[][],
+  columnTypes?: Record<string, unknown> | null,
+): CoerceGridRowsResult {
+  const issues: GridValidationIssue[] = []
   const coercedRows = rows.map((row, rowIndex) => row.map((value, columnIndex) => {
     const columnName = columns[columnIndex]
     if (!columnName) {
       return value
     }
 
-    const result = coerceGridValue(columnName, value, value)
+    const result = coerceGridValue(columnName, value, value, columnTypes)
     if (result.error) {
-      errors.push(`Row ${rowIndex + 1}, column ${columnName}: ${result.error}`)
+      issues.push({ rowIndex, columnName, message: result.error })
     }
 
     return result.value
   }))
 
-  return { rows: coercedRows, errors }
+  return { rows: coercedRows, issues, errors: issues.map(formatValidationIssue) }
 }
-
 interface ApplyClipboardMatrixOptions {
   rows: any[][]
   columns: string[]
+  columnTypes?: Record<string, unknown> | null
   startRowIndex: number
   startColIndex: number
   matrix: string[][]
   createEmptyRow: () => any[]
 }
-
 export function applyClipboardMatrix({
   rows,
   columns,
+  columnTypes,
   startRowIndex,
   startColIndex,
   matrix,
   createEmptyRow,
 }: ApplyClipboardMatrixOptions): ApplyClipboardMatrixResult {
   const result = rows.map((row) => [...row])
-  const errors: string[] = []
+  const issues: GridValidationIssue[] = []
   const requiredRowCount = startRowIndex + matrix.length
 
   while (result.length < requiredRowCount) {
@@ -168,15 +253,15 @@ export function applyClipboardMatrix({
         continue
       }
 
-      const { value, error } = coerceGridValue(columnName, sourceRow[columnOffset] ?? '', targetRow[targetColIndex])
+      const { value, error } = coerceGridValue(columnName, sourceRow[columnOffset] ?? '', targetRow[targetColIndex], columnTypes)
 
       if (error) {
-        errors.push(`Row ${targetRowIndex + 1}, column ${columnName}: ${error}`)
+        issues.push({ rowIndex: targetRowIndex, columnName, message: error })
       }
 
       targetRow[targetColIndex] = value
     }
   }
 
-  return { rows: result, errors }
+  return { rows: result, issues, errors: issues.map(formatValidationIssue) }
 }

--- a/frontend/src/composables/__tests__/useEntities.test.ts
+++ b/frontend/src/composables/__tests__/useEntities.test.ts
@@ -1,25 +1,62 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
+import { defineComponent } from 'vue'
+import { mount, type VueWrapper } from '@vue/test-utils'
 import { useEntities } from '../useEntities'
 import { useEntityStore } from '@/stores'
 import type { EntityResponse, EntityCreateRequest, EntityUpdateRequest } from '@/api/entities'
 
-// Mock console methods
-const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+function createEntityResponse(name: string, entityData: Record<string, unknown>): EntityResponse {
+  return {
+    name,
+    entity_data: entityData,
+    etag: `${name}-etag`,
+  }
+}
+
+let consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+let mountedWrappers: VueWrapper[] = []
+
+function useEntitiesInSetup(options: Parameters<typeof useEntities>[0]): ReturnType<typeof useEntities> {
+  let result: ReturnType<typeof useEntities> | null = null
+
+  const wrapper = mount(
+    defineComponent({
+      setup() {
+        result = useEntities(options)
+        return () => null
+      },
+    })
+  )
+
+  mountedWrappers.push(wrapper)
+
+  if (!result) {
+    throw new Error('Failed to create useEntities test harness')
+  }
+
+  return result
+}
 
 describe('useEntities', () => {
   beforeEach(() => {
+    vi.restoreAllMocks()
     setActivePinia(createPinia())
+    mountedWrappers = []
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
     consoleError.mockClear()
   })
 
   afterEach(() => {
+    for (const wrapper of mountedWrappers) {
+      wrapper.unmount()
+    }
     vi.restoreAllMocks()
   })
 
   describe('initialization', () => {
     it('should initialize with required projectName', () => {
-      const { loading, error, entities, currentProjectName } = useEntities({
+      const { loading, error, entities, currentProjectName } = useEntitiesInSetup({
         projectName: 'test-project',
         autoFetch: false,
       })
@@ -34,32 +71,33 @@ describe('useEntities', () => {
       const store = useEntityStore()
       vi.spyOn(store, 'fetchEntities')
 
-      useEntities({ projectName: 'test-project', autoFetch: false })
+      useEntitiesInSetup({ projectName: 'test-project', autoFetch: false })
 
       expect(store.fetchEntities).not.toHaveBeenCalled()
     })
 
     it('should accept entityName option', () => {
-      const { selectedEntity } = useEntities({
+      const store = useEntityStore()
+      vi.spyOn(store, 'selectEntity').mockResolvedValue(null as never)
+
+      const { selectedEntity } = useEntitiesInSetup({
         projectName: 'test-project',
         autoFetch: false,
         entityName: 'test-entity',
       })
 
       expect(selectedEntity.value).toBeNull()
+      expect(store.selectEntity).toHaveBeenCalledWith('test-project', 'test-entity')
     })
   })
 
   describe('computed state', () => {
     it('should expose entities from store', () => {
       const store = useEntityStore()
-      const { entities } = useEntities({ projectName: 'test-project', autoFetch: false })
+      const { entities } = useEntitiesInSetup({ projectName: 'test-project', autoFetch: false })
 
       const mockEntities: EntityResponse[] = [
-        {
-          name: 'entity1',
-          entity_data: { type: 'table', table: 'table1' },
-        },
+        createEntityResponse('entity1', { type: 'table', table: 'table1' }),
       ]
 
       store.$patch((state) => {
@@ -71,12 +109,9 @@ describe('useEntities', () => {
 
     it('should expose selectedEntity from store', () => {
       const store = useEntityStore()
-      const { selectedEntity } = useEntities({ projectName: 'test-project', autoFetch: false })
+      const { selectedEntity } = useEntitiesInSetup({ projectName: 'test-project', autoFetch: false })
 
-      const mockEntity: EntityResponse = {
-        name: 'selected',
-        entity_data: { type: 'table', table: 'table1' },
-      }
+      const mockEntity: EntityResponse = createEntityResponse('selected', { type: 'table', table: 'table1' })
 
       store.$patch((state) => {
         state.selectedEntity = mockEntity
@@ -87,7 +122,7 @@ describe('useEntities', () => {
 
     it('should expose currentProjectName from store', () => {
       const store = useEntityStore()
-      const { currentProjectName } = useEntities({ projectName: 'test-project', autoFetch: false })
+      const { currentProjectName } = useEntitiesInSetup({ projectName: 'test-project', autoFetch: false })
 
       store.$patch({ currentProjectName: 'test-project' })
 
@@ -96,7 +131,7 @@ describe('useEntities', () => {
 
     it('should expose loading state from store', () => {
       const store = useEntityStore()
-      const { loading } = useEntities({ projectName: 'test-project', autoFetch: false })
+      const { loading } = useEntitiesInSetup({ projectName: 'test-project', autoFetch: false })
 
       store.$patch({ loading: true })
       expect(loading.value).toBe(true)
@@ -107,7 +142,7 @@ describe('useEntities', () => {
 
     it('should expose error state from store', () => {
       const store = useEntityStore()
-      const { error } = useEntities({ projectName: 'test-project', autoFetch: false })
+      const { error } = useEntitiesInSetup({ projectName: 'test-project', autoFetch: false })
 
       store.$patch({ error: 'Test error' })
       expect(error.value).toBe('Test error')
@@ -118,7 +153,7 @@ describe('useEntities', () => {
 
     it('should expose hasUnsavedChanges from store', () => {
       const store = useEntityStore()
-      const { hasUnsavedChanges } = useEntities({ projectName: 'test-project', autoFetch: false })
+      const { hasUnsavedChanges } = useEntitiesInSetup({ projectName: 'test-project', autoFetch: false })
 
       store.$patch({ hasUnsavedChanges: true })
       expect(hasUnsavedChanges.value).toBe(true)
@@ -128,10 +163,10 @@ describe('useEntities', () => {
   describe('computed getters', () => {
     it('should expose entitiesByType from store', () => {
       const store = useEntityStore()
-      const { entitiesByType } = useEntities({ projectName: 'test-project', autoFetch: false })
+      const { entitiesByType } = useEntitiesInSetup({ projectName: 'test-project', autoFetch: false })
 
       const mockEntitiesByType = {
-        table: [{ name: 'entity1', entity_data: { type: 'table', table: 'table1' } }],
+        table: [createEntityResponse('entity1', { type: 'table', table: 'table1' })],
       }
 
       vi.spyOn(store, 'entitiesByType', 'get').mockReturnValue(mockEntitiesByType)
@@ -141,11 +176,11 @@ describe('useEntities', () => {
 
     it('should compute entityCount correctly', () => {
       const store = useEntityStore()
-      const { entityCount } = useEntities({ projectName: 'test-project', autoFetch: false })
+      const { entityCount } = useEntitiesInSetup({ projectName: 'test-project', autoFetch: false })
 
       const mockEntities: EntityResponse[] = [
-        { name: 'entity1', entity_data: { type: 'table', table: 'table1' } },
-        { name: 'entity2', entity_data: { type: 'table', table: 'table2' } },
+        createEntityResponse('entity1', { type: 'table', table: 'table1' }),
+        createEntityResponse('entity2', { type: 'table', table: 'table2' }),
       ]
 
       store.$patch((state) => {
@@ -157,9 +192,9 @@ describe('useEntities', () => {
 
     it('should expose rootEntities from store', () => {
       const store = useEntityStore()
-      const { rootEntities } = useEntities({ projectName: 'test-project', autoFetch: false })
+      const { rootEntities } = useEntitiesInSetup({ projectName: 'test-project', autoFetch: false })
 
-      const mockRootEntities = [{ name: 'root', entity_data: { type: 'table', table: 'table1' } }]
+      const mockRootEntities = [createEntityResponse('root', { type: 'table', table: 'table1' })]
 
       vi.spyOn(store, 'rootEntities', 'get').mockReturnValue(mockRootEntities)
 
@@ -167,7 +202,7 @@ describe('useEntities', () => {
     })
 
     it('should check if entities are empty', () => {
-      const { isEmpty } = useEntities({ projectName: 'test-project', autoFetch: false })
+      const { isEmpty } = useEntitiesInSetup({ projectName: 'test-project', autoFetch: false })
 
       expect(isEmpty.value).toBe(true)
     })
@@ -178,7 +213,7 @@ describe('useEntities', () => {
       const store = useEntityStore()
       vi.spyOn(store, 'fetchEntities').mockResolvedValue()
 
-      const { fetch, initialized } = useEntities({ projectName: 'test-project', autoFetch: false })
+      const { fetch, initialized } = useEntitiesInSetup({ projectName: 'test-project', autoFetch: false })
 
       expect(initialized.value).toBe(false)
 
@@ -193,7 +228,7 @@ describe('useEntities', () => {
       const error = new Error('Fetch failed')
       vi.spyOn(store, 'fetchEntities').mockRejectedValue(error)
 
-      const { fetch } = useEntities({ projectName: 'test-project', autoFetch: false })
+      const { fetch } = useEntitiesInSetup({ projectName: 'test-project', autoFetch: false })
 
       await expect(fetch()).rejects.toThrow('Fetch failed')
     })
@@ -202,14 +237,11 @@ describe('useEntities', () => {
   describe('select action', () => {
     it('should select an entity', async () => {
       const store = useEntityStore()
-      const mockEntity: EntityResponse = {
-        name: 'selected',
-        entity_data: { type: 'table', table: 'table1' },
-      }
+      const mockEntity: EntityResponse = createEntityResponse('selected', { type: 'table', table: 'table1' })
 
       vi.spyOn(store, 'selectEntity').mockResolvedValue(mockEntity)
 
-      const { select } = useEntities({ projectName: 'test-project', autoFetch: false })
+      const { select } = useEntitiesInSetup({ projectName: 'test-project', autoFetch: false })
       const result = await select('selected')
 
       expect(store.selectEntity).toHaveBeenCalledWith('test-project', 'selected')
@@ -221,7 +253,7 @@ describe('useEntities', () => {
       const error = new Error('Select failed')
       vi.spyOn(store, 'selectEntity').mockRejectedValue(error)
 
-      const { select } = useEntities({ projectName: 'test-project', autoFetch: false })
+      const { select } = useEntitiesInSetup({ projectName: 'test-project', autoFetch: false })
 
       await expect(select('nonexistent')).rejects.toThrow('Select failed')
     })
@@ -234,14 +266,11 @@ describe('useEntities', () => {
         name: 'new-entity',
         entity_data: { type: 'table', table: 'new_table' },
       }
-      const mockEntity: EntityResponse = {
-        name: 'new-entity',
-        entity_data: { type: 'table', table: 'new_table' },
-      }
+      const mockEntity: EntityResponse = createEntityResponse('new-entity', { type: 'table', table: 'new_table' })
 
       vi.spyOn(store, 'createEntity').mockResolvedValue(mockEntity)
 
-      const { create } = useEntities({ projectName: 'test-project', autoFetch: false })
+      const { create } = useEntitiesInSetup({ projectName: 'test-project', autoFetch: false })
       const result = await create(createRequest)
 
       expect(store.createEntity).toHaveBeenCalledWith('test-project', createRequest)
@@ -253,7 +282,7 @@ describe('useEntities', () => {
       const error = new Error('Create failed')
       vi.spyOn(store, 'createEntity').mockRejectedValue(error)
 
-      const { create } = useEntities({ projectName: 'test-project', autoFetch: false })
+      const { create } = useEntitiesInSetup({ projectName: 'test-project', autoFetch: false })
       const createRequest: EntityCreateRequest = {
         name: 'invalid',
         entity_data: { type: 'table', table: 'invalid_table' },
@@ -269,14 +298,11 @@ describe('useEntities', () => {
       const updateRequest: EntityUpdateRequest = {
         entity_data: { type: 'table', table: 'updated_table' },
       }
-      const mockEntity: EntityResponse = {
-        name: 'test-entity',
-        entity_data: { type: 'table', table: 'updated_table' },
-      }
+      const mockEntity: EntityResponse = createEntityResponse('test-entity', { type: 'table', table: 'updated_table' })
 
       vi.spyOn(store, 'updateEntity').mockResolvedValue(mockEntity)
 
-      const { update } = useEntities({ projectName: 'test-project', autoFetch: false })
+      const { update } = useEntitiesInSetup({ projectName: 'test-project', autoFetch: false })
       const result = await update('test-entity', updateRequest)
 
       expect(store.updateEntity).toHaveBeenCalledWith('test-project', 'test-entity', updateRequest)
@@ -288,7 +314,7 @@ describe('useEntities', () => {
       const error = new Error('Update failed')
       vi.spyOn(store, 'updateEntity').mockRejectedValue(error)
 
-      const { update } = useEntities({ projectName: 'test-project', autoFetch: false })
+      const { update } = useEntitiesInSetup({ projectName: 'test-project', autoFetch: false })
       const updateRequest: EntityUpdateRequest = { entity_data: { type: 'table', table: 'new' } }
 
       await expect(update('test-entity', updateRequest)).rejects.toThrow('Update failed')
@@ -300,7 +326,7 @@ describe('useEntities', () => {
       const store = useEntityStore()
       vi.spyOn(store, 'deleteEntity').mockResolvedValue()
 
-      const { remove } = useEntities({ projectName: 'test-project', autoFetch: false })
+      const { remove } = useEntitiesInSetup({ projectName: 'test-project', autoFetch: false })
       await remove('test-entity')
 
       expect(store.deleteEntity).toHaveBeenCalledWith('test-project', 'test-entity')
@@ -311,7 +337,7 @@ describe('useEntities', () => {
       const error = new Error('Delete failed')
       vi.spyOn(store, 'deleteEntity').mockRejectedValue(error)
 
-      const { remove } = useEntities({ projectName: 'test-project', autoFetch: false })
+      const { remove } = useEntitiesInSetup({ projectName: 'test-project', autoFetch: false })
 
       await expect(remove('test-entity')).rejects.toThrow('Delete failed')
     })
@@ -320,16 +346,13 @@ describe('useEntities', () => {
   describe('helper methods', () => {
     it('should get entity by name', () => {
       const store = useEntityStore()
-      const mockEntity: EntityResponse = {
-        name: 'test-entity',
-        entity_data: { type: 'table', table: 'table1' },
-      }
+      const mockEntity: EntityResponse = createEntityResponse('test-entity', { type: 'table', table: 'table1' })
 
       store.$patch((state) => {
         state.entities = [mockEntity]
       })
 
-      const { entityByName } = useEntities({ projectName: 'test-project', autoFetch: false })
+      const { entityByName } = useEntitiesInSetup({ projectName: 'test-project', autoFetch: false })
       const result = entityByName('test-entity')
 
       expect(result).toEqual(mockEntity)
@@ -341,7 +364,7 @@ describe('useEntities', () => {
       const store = useEntityStore()
       vi.spyOn(store, 'clearError')
 
-      const { clearError } = useEntities({ projectName: 'test-project', autoFetch: false })
+      const { clearError } = useEntitiesInSetup({ projectName: 'test-project', autoFetch: false })
       clearError()
 
       expect(store.clearError).toHaveBeenCalled()
@@ -353,7 +376,7 @@ describe('useEntities', () => {
       const store = useEntityStore()
       vi.spyOn(store, 'fetchEntities').mockResolvedValue()
 
-      const { fetch } = useEntities({ projectName: 'project1', autoFetch: false })
+      const { fetch } = useEntitiesInSetup({ projectName: 'project1', autoFetch: false })
 
       await fetch()
       expect(store.fetchEntities).toHaveBeenCalledWith('project1')

--- a/frontend/src/types/entity.ts
+++ b/frontend/src/types/entity.ts
@@ -78,6 +78,7 @@ export interface Entity {
   surrogate_id?: string | null
   keys?: string[]
   columns?: string[]
+  column_types?: Record<string, string> | null
   extra_columns?: Record<string, any>
   foreign_keys?: ForeignKeyConfig[]
   unnest?: UnnestConfig | null

--- a/frontend/src/views/HelpView.vue
+++ b/frontend/src/views/HelpView.vue
@@ -106,7 +106,9 @@ function getSectionFromHash(hash: string): string {
 
 watch(
   () => [currentDoc.value, route.hash] as const,
-  async ([docPath, hash], [previousDocPath, previousHash]) => {
+  async ([docPath, hash], previousValue) => {
+    const [previousDocPath, previousHash] = previousValue ?? [undefined, undefined]
+
     if (docPath !== previousDocPath) {
       await loadHelp(docPath)
     }


### PR DESCRIPTION
I’m pulling the committed diff summary now so I can give you a PR-ready title and body based on the actual staged change, not a hand-written recap.

Ran terminal command:  cd /home/roger/source/sead_shape_shifter && git show --stat --summary --format=medium 92b9dd1d

Ran terminal command:  cd /home/roger/source/sead_shape_shifter && git show --name-only --format=oneline --no-patch 92b9dd1d && git diff-tree --no-commit-id --name-only -r 92b9dd1d

Here’s a PR-ready summary based on commit `92b9dd1d`.

**Title**

Support fixed entity column type editing in the frontend

**Body**

## Summary

This PR adds frontend support for fixed-entity `column_types` editing and round-trip persistence.

It wires `column_types` through the fixed-entity dialog state in EntityFormDialog.vue and entity.ts, adds per-column type controls and validation handling in FixedValuesGrid.vue and fixedValuesGridClipboard.ts, and keeps unsupported declared types preserved during load/save.

The PR also includes the follow-up frontend cleanup needed to keep the repo buildable and the touched tests quiet:
entities.test.ts,
EntityListCard.test.ts,
useEntities.test.ts,
entityFormMaterialization.ts, and
HelpView.vue.

## User-visible behavior

- Fixed entities now expose per-column type selectors in the editor.
- Explicit `int` and `string` declarations are supported in the grid UI.
- Unsupported declared types such as `date`, `bool`, and `float` are preserved rather than dropped or coerced incorrectly.
- Validation remains inline at the row/cell level, with grouped top-level summaries by column.
