### PR TITLE
feat(target-model): complete SEAD target-model follow-up tranche

### DIFF
--- a/backend/app/validators/target_model_validator.py
+++ b/backend/app/validators/target_model_validator.py
@@ -14,10 +14,11 @@ from typing import Any
 from loguru import logger
 
 from backend.app.mappers.validation_mapper import ValidationMapper
-from backend.app.models.validation import ValidationError
+from backend.app.models.validation import ValidationCategory, ValidationError, ValidationPriority
 from src.model import ShapeShiftProject
 from src.target_model.conformance import ConformanceIssue, TargetModelConformanceValidator
 from src.target_model.models import TargetModel
+from src.target_model.spec_validator import SpecValidationIssue, TargetModelSpecValidator
 
 
 class TargetModelValidator:
@@ -57,6 +58,24 @@ class TargetModelValidator:
                     suggestion="Ensure the target model YAML matches the TargetModel schema.",
                 )
             ]
+
+        spec_issues: list[SpecValidationIssue] = TargetModelSpecValidator().validate(target_model)
+        if spec_issues:
+            logger.debug(f"Target-model spec validation: {len(spec_issues)} issue(s) found")
+            errors: list[ValidationError] = []
+            for issue in spec_issues:
+                error = ValidationMapper.from_core_issue(
+                    issue,
+                    default_category=ValidationCategory.CONFORMANCE,
+                    default_priority=ValidationPriority.HIGH,
+                    default_suggestion="Fix the target model specification and rerun validation.",
+                    default_auto_fixable=False,
+                )
+                error.category = ValidationCategory.CONFORMANCE
+                error.priority = ValidationPriority.HIGH
+                errors.append(error)
+
+            return errors
 
         issues: list[ConformanceIssue] = TargetModelConformanceValidator().validate(target_model, project)
         errors: list[ValidationError] = [ValidationMapper.from_conformance_issue(issue) for issue in issues]

--- a/backend/tests/validators/test_target_model_validator.py
+++ b/backend/tests/validators/test_target_model_validator.py
@@ -133,6 +133,43 @@ class TestTargetModelValidatorErrorPaths:
 
         assert any(e.code == "MISSING_REQUIRED_COLUMN" for e in errors)
 
+    def test_unknown_foreign_key_entity_returns_specific_spec_issue(self):
+        """Spec self-consistency issues should surface their specific code, not INVALID_TARGET_MODEL."""
+        project = _make_project({})
+        target_model_data = _minimal_target_model(
+            entities={
+                "site": {
+                    "public_id": "site_id",
+                    "foreign_keys": [{"entity": "location", "required": True}],
+                }
+            }
+        )
+
+        errors = TargetModelValidator().validate(target_model_data, project)
+
+        assert [error.code for error in errors] == ["UNKNOWN_FOREIGN_KEY_ENTITY"]
+        assert errors[0].entity == "site"
+        assert errors[0].field is None
+        assert errors[0].suggestion == "Fix the target model specification and rerun validation."
+
+    def test_aggregate_parent_spec_issue_blocks_conformance_and_surfaces_specific_code(self):
+        """Aggregate-parent self-consistency issues should be returned directly before project conformance runs."""
+        project = _make_project({"sample": _minimal_entity(public_id="sample_id")})
+        target_model_data = _minimal_target_model(
+            entities={
+                "sample": {"public_id": "sample_id"},
+                "sample_description": {
+                    "public_id": "sample_description_id",
+                    "aggregate_parent": "sample",
+                },
+            }
+        )
+
+        errors = TargetModelValidator().validate(target_model_data, project)
+
+        assert [error.code for error in errors] == ["MISSING_AGGREGATE_PARENT_FOREIGN_KEY"]
+        assert errors[0].entity == "sample_description"
+
 
 # ---------------------------------------------------------------------------
 # ValidationError shape produced by the adapter
@@ -155,3 +192,25 @@ class TestValidationErrorShape:
             assert err.priority == ValidationPriority.HIGH
             assert err.auto_fixable is False
             assert err.suggestion is None
+
+    def test_spec_errors_have_correct_metadata(self):
+        """Spec validation errors should use conformance metadata and keep their specific code."""
+        project = _make_project({})
+        target_model_data = _minimal_target_model(
+            entities={
+                "site": {
+                    "public_id": "site_id",
+                    "foreign_keys": [{"entity": "location", "required": True}],
+                }
+            }
+        )
+
+        errors = TargetModelValidator().validate(target_model_data, project)
+
+        assert errors, "Expected at least one target-model spec error"
+        for err in errors:
+            assert err.severity == "error"
+            assert err.category == ValidationCategory.CONFORMANCE
+            assert err.priority == ValidationPriority.HIGH
+            assert err.auto_fixable is False
+            assert err.suggestion == "Fix the target model specification and rerun validation."

--- a/docs/CONFIGURATION_GUIDE.md
+++ b/docs/CONFIGURATION_GUIDE.md
@@ -78,7 +78,7 @@ metadata:                             # Metadata definitions (required)
 - **description**: Detailed description of what this configuration does (supports multi-line strings using `|`)
 - **version**: Semantic version string (e.g., "1.0.0", "2.1.3") for tracking configuration changes
 - **default_entity**: Reference to an existing entity used as the default source for `data` type entities
-- **target_model**: Reference to a target model specification. Accepted as a `@include:` directive pointing to a YAML file (`"@include: resources/target_models/sead_standard_model.yml"`) or as an inline mapping. When present, the **Check Conformance** button in the editor validates the project entities against the spec. See [TARGET_MODEL_GUIDE.md](TARGET_MODEL_GUIDE.md) for the full target model format.
+- **target_model**: Reference to a target model specification. Accepted as a `@include:` directive pointing to a YAML file (`"@include: resources/target_models/sead_superset_model.yml"`) or as an inline mapping. When present, the **Check Conformance** button in the editor validates the project entities against the spec. See [TARGET_MODEL_GUIDE.md](TARGET_MODEL_GUIDE.md) for the full target model format.
 
 ### Examples
 
@@ -98,7 +98,7 @@ metadata:
     Transforms data to match SEAD Clearinghouse schema.
   version: "2.1.0"
   default_entity: sample_data
-  target_model: "@include: resources/target_models/sead_standard_model.yml"
+  target_model: "@include: resources/target_models/sead_superset_model.yml"
 ```
 
 ## Entity Section

--- a/docs/TARGET_MODEL_GUIDE.md
+++ b/docs/TARGET_MODEL_GUIDE.md
@@ -12,14 +12,14 @@ Target model specs are optional. Existing projects without a `target_model` refe
 
 ## Quick Start
 
-1. Pick or create a spec file — e.g., `resources/target_models/sead_standard_model.yml` (the SEAD Clearinghouse spec ships with Shape Shifter).
+1. Pick or create a spec file — e.g., `resources/target_models/sead_superset_model.yml` (the current bundled SEAD superset spec ships with Shape Shifter).
 2. Add a `target_model` reference to your project's `metadata` section:
 
 ```yaml
 metadata:
   type: 'shapeshifter-project'
   name: "Dendrochronology Import"
-  target_model: "@include: resources/target_models/sead_standard_model.yml"
+  target_model: "@include: resources/target_models/sead_superset_model.yml"
 ```
 
 3. Open your project in the editor, go to the **Validate** tab, and click **Check Conformance**.
@@ -29,14 +29,14 @@ metadata:
 
 ## File Location
 
-The built-in SEAD spec lives at `resources/target_models/sead_standard_model.yml`. Custom or project-specific specs can live anywhere; reference them with a path relative to the project file or an absolute path.
+The current bundled SEAD spec lives at `resources/target_models/sead_superset_model.yml`. Custom or project-specific specs can live anywhere; reference them with a path relative to the project file or an absolute path.
 
 Recommended layout for project-specific specs:
 
 ```
 target_models/
   specs/
-    sead_standard_model.yml           ← bundled SEAD clearinghouse spec
+    sead_superset_model.yml           ← bundled SEAD superset spec
     my_museum.yml         ← custom target model
 ```
 
@@ -50,7 +50,7 @@ Use the `metadata.target_model` field. The value may be either a file reference 
 ```yaml
 metadata:
   type: 'shapeshifter-project'
-  target_model: "@include: resources/target_models/sead_standard_model.yml"
+  target_model: "@include: resources/target_models/sead_superset_model.yml"
 ```
 
 **Inline definition (for small custom models):**
@@ -80,6 +80,8 @@ The Metadata Editor in the project workspace surfaces this as a **Target Model**
 ---
 
 ## Target Model File Format
+
+Target model files are parsed with strict Pydantic models. Unknown keys in these blocks are rejected during load instead of being silently ignored.
 
 ### Top-Level Structure
 
@@ -125,24 +127,27 @@ Each key is an entity name that must match the project entity name. Each value i
 
 ```yaml
 entities:
-  location:
+  site:
     role: lookup
     required: true
-    description: "Geographic location"
+    description: "Archaeological site"
     domains: [core, spatial]
-    target_table: tbl_locations
-    public_id: location_id
-    identity_columns: [location_type_id, location_name]
+    target_table: tbl_sites
+    public_id: site_id
+    identity_columns: [site_name]
+    identity_tracking: reconciled
+    reconciliation: reconcile-fuzzy
     columns:
-      location_name:
+      site_name:
         required: true
         type: string
         nullable: false
     unique_sets:
-      - [location_type_id, location_name]
+      - [site_name]
     foreign_keys:
-      - entity: location_type
+      - entity: location
         required: true
+        via: site_location
 ```
 
 #### Entity Spec Fields
@@ -159,6 +164,9 @@ entities:
 | `columns`          | No       | Map of column name → column spec; conformance checks these against the project |
 | `unique_sets`      | No       | List of unique-set column groups                                               |
 | `foreign_keys`     | No       | List of foreign key specs                                                      |
+| `identity_tracking`| No       | Identity handling mode: `tracked`, `reconciled`, `derived`, or `child`        |
+| `reconciliation`   | No       | Expected matching or allocation mode for this entity                           |
+| `aggregate_parent` | No       | Parent entity name when this entity inherits aggregate identity                |
 
 ---
 
@@ -194,8 +202,9 @@ columns:
 | Field      | Required | Description                                                                                          |
 |------------|----------|------------------------------------------------------------------------------------------------------|
 | `required` | No       | `true` means the project entity must expose this column                                              |
-| `type`     | No       | Hint type: `string`, `integer`, `decimal`, `boolean` (informational; no hard type enforcement in v1) |
+| `type`     | No       | Hint type such as `string`, `integer`, `decimal`, `boolean`, or `date` (informational in v1)       |
 | `nullable` | No       | Whether the column is expected to allow null values (informational)                                  |
+| `description` | No    | Human-readable note for reviewers, generated docs, and editor help                                   |
 
 Shape Shifter counts a column as present in a project entity when it appears as:
 - an explicit entry in `columns` or `keys`
@@ -212,6 +221,7 @@ Shape Shifter counts a column as present in a project entity when it appears as:
 foreign_keys:
   - entity: location
     required: true
+    via: site_location
   - entity: site_type
     required: false
 ```
@@ -220,8 +230,33 @@ foreign_keys:
 |------------|----------|-------------------------------------------------------------------------------------|
 | `entity`   | Yes      | Name of the target entity this FK must point to                                     |
 | `required` | No       | `true` means the project entity must declare a FK to this entity (default: `false`) |
+| `via`      | No       | Bridge entity name for many-to-many relationships such as `site -> site_location -> location` |
 
 Conformance checks whether the project entity has at least one foreign key whose target matches the required entity name.
+
+When `via` is present, conformance first checks the source entity points to the bridge entity, then checks whether the bridge points to the ultimate target entity.
+
+---
+
+### Identity And Reconciliation Fields
+
+These fields describe how an entity participates in SIMS identity handling and lookup/allocation workflows.
+
+Shape Shifter validates these fields together when a target model loads:
+
+- `aggregate_parent` must name another entity in the same model
+- entities with `aggregate_parent` must also declare a foreign key to that parent
+- `identity_tracking: child` requires `aggregate_parent`
+- `tracked` entities resolve to `allocate`
+- `derived` entities resolve to `derive`
+- `child` entities must not declare a reconciliation strategy
+- `reconciled` entities must resolve to one of `reconcile-exact`, `reconcile-fuzzy`, `lookup-only`, or `lookup-extensible`
+
+| Field | Allowed values | Description |
+|-------|----------------|-------------|
+| `identity_tracking` | `tracked`, `reconciled`, `derived`, `child` | Declares whether the entity gets its own tracked identity, is matched by business keys, derives identity from related rows, or inherits from an aggregate parent |
+| `reconciliation` | `allocate`, `reconcile-exact`, `reconcile-fuzzy`, `lookup-only`, `lookup-extensible`, `derive` | Declares the expected matching or allocation mode for this entity |
+| `aggregate_parent` | Entity name | Required when identity is inherited from a parent aggregate such as `analysis_entity` or `sample` |
 
 ---
 
@@ -242,10 +277,16 @@ naming:
 
 ```yaml
 constraints:
-  - type: no_orphan_facts
+  - type: no_circular_dependencies
 ```
 
-Global constraints are planned for future validation phases. `no_orphan_facts` is declared in the SEAD spec but not yet enforced by the conformance engine. It records the *intent* that every fact entity must be reachable from at least one required lookup.
+| Field | Required | Description |
+|-------|----------|-------------|
+| `type` | Yes | Global rule name applied to the whole target model |
+
+Current constraints are modeled as simple typed entries. Add new constraint-specific keys only after extending the Pydantic schema.
+
+Global constraints are planned for future validation phases. `no_orphan_facts` is declared in the SEAD spec but not yet enforced by the conformance engine. It records the intended rule that every fact entity must be reachable from at least one required lookup.
 
 ---
 
@@ -257,8 +298,9 @@ When you click **Check Conformance** in the editor, Shape Shifter:
 
 1. Loads the project and resolves the `target_model` reference (expanding `@include:` if needed).
 2. Parses the target model spec into a `TargetModel` domain object.
-3. Runs the five built-in conformance validators against the resolved project.
-4. Returns a list of `ConformanceIssue` objects, each including a code, message, affected entity and field, and a suggestion.
+3. Runs the target-model spec validator to check self-consistency, including unknown FK targets, invalid aggregate-parent relationships, and invalid identity-tracking or reconciliation combinations.
+4. Runs the built-in conformance validators against the resolved project.
+5. Returns a list of `ConformanceIssue` objects, each including a code, message, affected entity and field, and a suggestion.
 
 Conformance results appear in their own **Conformance** panel in the Validate tab, separate from structural and data validation results.
 
@@ -291,7 +333,7 @@ The conformance engine can also be used from the CLI for quick checks:
 
 ```bash
 python -m src.target_model.conformance \
-  --spec resources/target_models/sead_standard_model.yml \
+  --spec resources/target_models/sead_superset_model.yml \
   --project data/projects/my_project/shapeshifter.yml
 ```
 
@@ -303,18 +345,18 @@ The template generator creates a starter project YAML pre-populated with the ent
 
 ```bash
 python -m src.target_model.template_generator \
-  --spec resources/target_models/sead_standard_model.yml \
+  --spec resources/target_models/sead_superset_model.yml \
   --output my_project_scaffold.yml
 
 # Filter to a specific domain
 python -m src.target_model.template_generator \
-  --spec resources/target_models/sead_standard_model.yml \
+  --spec resources/target_models/sead_superset_model.yml \
   --domain core \
   --output core_entities.yml
 
 # Include only specific entities
 python -m src.target_model.template_generator \
-  --spec resources/target_models/sead_standard_model.yml \
+  --spec resources/target_models/sead_superset_model.yml \
   --entities location,site,sample \
   --output minimal.yml
 ```
@@ -373,44 +415,47 @@ naming:
 
 ---
 
-## SEAD Clearinghouse Spec (`sead_standard_model.yml`)
+## SEAD Superset Spec (`sead_superset_model.yml`)
 
-The bundled SEAD spec at `resources/target_models/sead_standard_model.yml` currently covers 35 entities organized across these domains:
+The bundled SEAD superset spec at `resources/target_models/sead_superset_model.yml` currently covers 51 entities. It is intended to be the near-complete shared SEAD model from which individual Shape Shifter projects can select curated subsets.
 
 | Domain       | Entities                                                                                                                                                                |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `core`       | location, location_type, site, site_type, site_type_group, sample_group, sample, sample_type, method, dataset, master_dataset, project, citation                        |
-| `spatial`    | location, location_type, site, site_type                                                                                                                                |
-| `analysis`   | dataset, analysis_entity, abundance, abundance_element, abundance_element_group, abundance_modification, modification_type, abundance_property, abundance_element_group |
-| `taxa`       | taxa_tree_master, taxa_common_names                                                                                                                                     |
-| `dating`     | relative_ages, relative_dating, geochronology, dating_lab                                                                                                               |
-| `method`     | method, method_group                                                                                                                                                    |
-| `contact`    | contact, contact_type, dataset_contact                                                                                                                                  |
-| `excavation` | feature_type, feature, sample_feature                                                                                                                                   |
+| `core` | Core context entities such as `location`, `site`, `sample_group`, `sample`, `method`, `dataset`, `analysis_entity`, and provenance lookups |
+| `spatial` | Spatial context and coordinate-related entities such as `location`, `site_location`, `dimension`, and site or sample-group spatial extensions |
+| `sample-metadata` | Sample descriptions, notes, dimensions, and other sample-attached metadata entities |
+| `abundance` | Abundance observations, abundance property entities, and related classifiers |
+| `taxonomy` | Taxonomy entities such as `taxa_tree_master`, `taxa_common_names`, and taxonomy support lookups |
+| `dating` | Relative dating, chronology, dating lab, and uncertainty entities |
+| `provenance` | Project, dataset, citation, contact, and dataset-contact provenance entities |
 
-The SEAD spec uses `naming.public_id_suffix: "_id"` and declares `constraints: [{type: no_orphan_facts}]`.
+The SEAD superset spec uses `naming.public_id_suffix: "_id"` and declares `constraints: [{type: no_orphan_facts}]`.
 
 ---
 
 ## Generating Documentation from a Target Model
 
-`scripts/generate_target_model_docs.py` produces human-readable output from any target model YAML spec. Three formats are supported:
+`scripts/generate_target_model_docs.py` produces human-readable output from any target model YAML spec. Four formats are supported:
 
 | Format     | Best for                              | Output file   |
 |------------|---------------------------------------|---------------|
 | `html`     | Stakeholder presentations, reference  | `<stem>.html` |
 | `excel`    | Review workshops, gap analysis        | `<stem>.xlsx` |
 | `markdown` | GitHub wikis, version-controlled docs | `<stem>.md`   |
+| `sims`     | SIMS entity register and identity review | `<stem>.sims.md` |
 
 ```bash
 # Generate all formats (default)
-python scripts/generate_target_model_docs.py resources/target_models/sead_standard_model.yml
+python scripts/generate_target_model_docs.py resources/target_models/sead_superset_model.yml
 
 # HTML only — recommended for sharing with archaeologists and data managers
-python scripts/generate_target_model_docs.py resources/target_models/sead_standard_model.yml --format html
+python scripts/generate_target_model_docs.py resources/target_models/sead_superset_model.yml --format html
 
 # Excel for gap-analysis workshops
-python scripts/generate_target_model_docs.py resources/target_models/sead_standard_model.yml --format excel
+python scripts/generate_target_model_docs.py resources/target_models/sead_superset_model.yml --format excel
+
+# SIMS entity register for Authority Service docs
+python scripts/generate_target_model_docs.py resources/target_models/sead_superset_model.yml --format sims
 
 # Custom output directory
 python scripts/generate_target_model_docs.py my_model.yml --format all --output-dir /tmp/model-docs

--- a/docs/TARGET_MODEL_GUIDE.md
+++ b/docs/TARGET_MODEL_GUIDE.md
@@ -417,11 +417,12 @@ naming:
 
 ## SEAD Superset Spec (`sead_superset_model.yml`)
 
-The bundled SEAD superset spec at `resources/target_models/sead_superset_model.yml` currently covers 61 entities. It is intended to be the near-complete shared SEAD model from which individual Shape Shifter projects can select curated subsets.
+The bundled SEAD superset spec at `resources/target_models/sead_superset_model.yml` currently covers 67 entities. It is intended to be the near-complete shared SEAD model from which individual Shape Shifter projects can select curated subsets.
 
 | Domain       | Entities                                                                                                                                                                |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `core` | Core context entities such as `location`, `site`, `sample_group`, `sample`, `method`, `dataset`, `analysis_entity`, and provenance lookups |
+| `analysis` | Generic analysis values, notes, identifiers, typed values, and qualifier-backed ranges attached to `analysis_entity` records |
 | `spatial` | Spatial context and coordinate-related entities such as `location`, `site_location`, `dimension`, and site, sample, or sample-group coordinate extensions |
 | `sample-metadata` | Sample and sample-group descriptions, locations, notes, horizons, dimensions, qualifier vocabularies, references, and other attached metadata entities |
 | `abundance` | Abundance observations, abundance property entities, and related classifiers |

--- a/docs/TARGET_MODEL_GUIDE.md
+++ b/docs/TARGET_MODEL_GUIDE.md
@@ -417,7 +417,7 @@ naming:
 
 ## SEAD Superset Spec (`sead_superset_model.yml`)
 
-The bundled SEAD superset spec at `resources/target_models/sead_superset_model.yml` currently covers 81 entities. It is intended to be the near-complete shared SEAD model from which individual Shape Shifter projects can select curated subsets.
+The bundled SEAD superset spec at `resources/target_models/sead_superset_model.yml` currently covers 82 entities. It is intended to be the near-complete shared SEAD model from which individual Shape Shifter projects can select curated subsets.
 
 | Domain       | Entities                                                                                                                                                                |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/docs/TARGET_MODEL_GUIDE.md
+++ b/docs/TARGET_MODEL_GUIDE.md
@@ -417,16 +417,16 @@ naming:
 
 ## SEAD Superset Spec (`sead_superset_model.yml`)
 
-The bundled SEAD superset spec at `resources/target_models/sead_superset_model.yml` currently covers 82 entities. It is intended to be the near-complete shared SEAD model from which individual Shape Shifter projects can select curated subsets.
+The bundled SEAD superset spec at `resources/target_models/sead_superset_model.yml` currently covers 92 entities. It is intended to be the near-complete shared SEAD model from which individual Shape Shifter projects can select curated subsets.
 
 | Domain       | Entities                                                                                                                                                                |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `core` | Core context entities such as `location`, `site`, `sample_group`, `sample`, `method`, `dataset`, `analysis_entity`, and provenance lookups |
 | `analysis` | Generic analysis values, value-class lookups, notes, identifiers, categorical, boolean, and numeric typed values, range variants, taxon counts, and analysis-value dimensions attached to `analysis_entity` records |
 | `spatial` | Spatial context and coordinate-related entities such as `location`, `site_location`, `dimension`, site property and national-grid-reference entities, and site, sample, or sample-group coordinate extensions |
-| `sample-metadata` | Sample and sample-group descriptions, sampling-context and horizon lookups, locations, notes, dimensions, qualifier vocabularies, references, and other attached metadata entities |
+| `sample-metadata` | Sample and sample-group descriptions, sampling-context and horizon lookups, locations, notes, colours, dimensions, qualifier vocabularies, references, and other attached metadata entities |
 | `abundance` | Abundance observations, shared property-type vocabularies, abundance property entities, and related classifiers |
-| `taxonomy` | Taxonomy entities such as `taxa_tree_master`, `taxa_common_names`, and taxonomy support lookups |
+| `taxonomy` | Taxonomy entities such as `taxa_tree_master`, `taxa_common_names`, synonyms, measured attributes, Red Data Book lookups, and related taxonomy support tables |
 | `dating` | Relative dating, chronology, dating lab, and uncertainty entities |
 | `provenance` | Project, dataset, citation, contact, and dataset-contact provenance entities |
 

--- a/docs/TARGET_MODEL_GUIDE.md
+++ b/docs/TARGET_MODEL_GUIDE.md
@@ -417,14 +417,14 @@ naming:
 
 ## SEAD Superset Spec (`sead_superset_model.yml`)
 
-The bundled SEAD superset spec at `resources/target_models/sead_superset_model.yml` currently covers 67 entities. It is intended to be the near-complete shared SEAD model from which individual Shape Shifter projects can select curated subsets.
+The bundled SEAD superset spec at `resources/target_models/sead_superset_model.yml` currently covers 73 entities. It is intended to be the near-complete shared SEAD model from which individual Shape Shifter projects can select curated subsets.
 
 | Domain       | Entities                                                                                                                                                                |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `core` | Core context entities such as `location`, `site`, `sample_group`, `sample`, `method`, `dataset`, `analysis_entity`, and provenance lookups |
-| `analysis` | Generic analysis values, notes, identifiers, typed values, and qualifier-backed ranges attached to `analysis_entity` records |
+| `analysis` | Generic analysis values, notes, identifiers, boolean and numeric typed values, range variants, taxon counts, and analysis-value dimensions attached to `analysis_entity` records |
 | `spatial` | Spatial context and coordinate-related entities such as `location`, `site_location`, `dimension`, and site, sample, or sample-group coordinate extensions |
-| `sample-metadata` | Sample and sample-group descriptions, locations, notes, horizons, dimensions, qualifier vocabularies, references, and other attached metadata entities |
+| `sample-metadata` | Sample and sample-group descriptions, sampling-context and horizon lookups, locations, notes, dimensions, qualifier vocabularies, references, and other attached metadata entities |
 | `abundance` | Abundance observations, abundance property entities, and related classifiers |
 | `taxonomy` | Taxonomy entities such as `taxa_tree_master`, `taxa_common_names`, and taxonomy support lookups |
 | `dating` | Relative dating, chronology, dating lab, and uncertainty entities |

--- a/docs/TARGET_MODEL_GUIDE.md
+++ b/docs/TARGET_MODEL_GUIDE.md
@@ -417,13 +417,13 @@ naming:
 
 ## SEAD Superset Spec (`sead_superset_model.yml`)
 
-The bundled SEAD superset spec at `resources/target_models/sead_superset_model.yml` currently covers 59 entities. It is intended to be the near-complete shared SEAD model from which individual Shape Shifter projects can select curated subsets.
+The bundled SEAD superset spec at `resources/target_models/sead_superset_model.yml` currently covers 61 entities. It is intended to be the near-complete shared SEAD model from which individual Shape Shifter projects can select curated subsets.
 
 | Domain       | Entities                                                                                                                                                                |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `core` | Core context entities such as `location`, `site`, `sample_group`, `sample`, `method`, `dataset`, `analysis_entity`, and provenance lookups |
 | `spatial` | Spatial context and coordinate-related entities such as `location`, `site_location`, `dimension`, and site, sample, or sample-group coordinate extensions |
-| `sample-metadata` | Sample and sample-group descriptions, locations, notes, horizons, dimensions, references, and other attached metadata entities |
+| `sample-metadata` | Sample and sample-group descriptions, locations, notes, horizons, dimensions, qualifier vocabularies, references, and other attached metadata entities |
 | `abundance` | Abundance observations, abundance property entities, and related classifiers |
 | `taxonomy` | Taxonomy entities such as `taxa_tree_master`, `taxa_common_names`, and taxonomy support lookups |
 | `dating` | Relative dating, chronology, dating lab, and uncertainty entities |

--- a/docs/TARGET_MODEL_GUIDE.md
+++ b/docs/TARGET_MODEL_GUIDE.md
@@ -417,12 +417,12 @@ naming:
 
 ## SEAD Superset Spec (`sead_superset_model.yml`)
 
-The bundled SEAD superset spec at `resources/target_models/sead_superset_model.yml` currently covers 73 entities. It is intended to be the near-complete shared SEAD model from which individual Shape Shifter projects can select curated subsets.
+The bundled SEAD superset spec at `resources/target_models/sead_superset_model.yml` currently covers 78 entities. It is intended to be the near-complete shared SEAD model from which individual Shape Shifter projects can select curated subsets.
 
 | Domain       | Entities                                                                                                                                                                |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `core` | Core context entities such as `location`, `site`, `sample_group`, `sample`, `method`, `dataset`, `analysis_entity`, and provenance lookups |
-| `analysis` | Generic analysis values, notes, identifiers, boolean and numeric typed values, range variants, taxon counts, and analysis-value dimensions attached to `analysis_entity` records |
+| `analysis` | Generic analysis values, value-class lookups, notes, identifiers, categorical, boolean, and numeric typed values, range variants, taxon counts, and analysis-value dimensions attached to `analysis_entity` records |
 | `spatial` | Spatial context and coordinate-related entities such as `location`, `site_location`, `dimension`, and site, sample, or sample-group coordinate extensions |
 | `sample-metadata` | Sample and sample-group descriptions, sampling-context and horizon lookups, locations, notes, dimensions, qualifier vocabularies, references, and other attached metadata entities |
 | `abundance` | Abundance observations, abundance property entities, and related classifiers |

--- a/docs/TARGET_MODEL_GUIDE.md
+++ b/docs/TARGET_MODEL_GUIDE.md
@@ -417,15 +417,15 @@ naming:
 
 ## SEAD Superset Spec (`sead_superset_model.yml`)
 
-The bundled SEAD superset spec at `resources/target_models/sead_superset_model.yml` currently covers 78 entities. It is intended to be the near-complete shared SEAD model from which individual Shape Shifter projects can select curated subsets.
+The bundled SEAD superset spec at `resources/target_models/sead_superset_model.yml` currently covers 81 entities. It is intended to be the near-complete shared SEAD model from which individual Shape Shifter projects can select curated subsets.
 
 | Domain       | Entities                                                                                                                                                                |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `core` | Core context entities such as `location`, `site`, `sample_group`, `sample`, `method`, `dataset`, `analysis_entity`, and provenance lookups |
 | `analysis` | Generic analysis values, value-class lookups, notes, identifiers, categorical, boolean, and numeric typed values, range variants, taxon counts, and analysis-value dimensions attached to `analysis_entity` records |
-| `spatial` | Spatial context and coordinate-related entities such as `location`, `site_location`, `dimension`, and site, sample, or sample-group coordinate extensions |
+| `spatial` | Spatial context and coordinate-related entities such as `location`, `site_location`, `dimension`, site property and national-grid-reference entities, and site, sample, or sample-group coordinate extensions |
 | `sample-metadata` | Sample and sample-group descriptions, sampling-context and horizon lookups, locations, notes, dimensions, qualifier vocabularies, references, and other attached metadata entities |
-| `abundance` | Abundance observations, abundance property entities, and related classifiers |
+| `abundance` | Abundance observations, shared property-type vocabularies, abundance property entities, and related classifiers |
 | `taxonomy` | Taxonomy entities such as `taxa_tree_master`, `taxa_common_names`, and taxonomy support lookups |
 | `dating` | Relative dating, chronology, dating lab, and uncertainty entities |
 | `provenance` | Project, dataset, citation, contact, and dataset-contact provenance entities |

--- a/docs/TARGET_MODEL_GUIDE.md
+++ b/docs/TARGET_MODEL_GUIDE.md
@@ -417,13 +417,13 @@ naming:
 
 ## SEAD Superset Spec (`sead_superset_model.yml`)
 
-The bundled SEAD superset spec at `resources/target_models/sead_superset_model.yml` currently covers 51 entities. It is intended to be the near-complete shared SEAD model from which individual Shape Shifter projects can select curated subsets.
+The bundled SEAD superset spec at `resources/target_models/sead_superset_model.yml` currently covers 55 entities. It is intended to be the near-complete shared SEAD model from which individual Shape Shifter projects can select curated subsets.
 
 | Domain       | Entities                                                                                                                                                                |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `core` | Core context entities such as `location`, `site`, `sample_group`, `sample`, `method`, `dataset`, `analysis_entity`, and provenance lookups |
 | `spatial` | Spatial context and coordinate-related entities such as `location`, `site_location`, `dimension`, and site or sample-group spatial extensions |
-| `sample-metadata` | Sample descriptions, notes, dimensions, and other sample-attached metadata entities |
+| `sample-metadata` | Sample descriptions, locations, notes, horizons, dimensions, and other sample-attached metadata entities |
 | `abundance` | Abundance observations, abundance property entities, and related classifiers |
 | `taxonomy` | Taxonomy entities such as `taxa_tree_master`, `taxa_common_names`, and taxonomy support lookups |
 | `dating` | Relative dating, chronology, dating lab, and uncertainty entities |

--- a/docs/TARGET_MODEL_GUIDE.md
+++ b/docs/TARGET_MODEL_GUIDE.md
@@ -417,13 +417,13 @@ naming:
 
 ## SEAD Superset Spec (`sead_superset_model.yml`)
 
-The bundled SEAD superset spec at `resources/target_models/sead_superset_model.yml` currently covers 55 entities. It is intended to be the near-complete shared SEAD model from which individual Shape Shifter projects can select curated subsets.
+The bundled SEAD superset spec at `resources/target_models/sead_superset_model.yml` currently covers 59 entities. It is intended to be the near-complete shared SEAD model from which individual Shape Shifter projects can select curated subsets.
 
 | Domain       | Entities                                                                                                                                                                |
 |--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `core` | Core context entities such as `location`, `site`, `sample_group`, `sample`, `method`, `dataset`, `analysis_entity`, and provenance lookups |
-| `spatial` | Spatial context and coordinate-related entities such as `location`, `site_location`, `dimension`, and site or sample-group spatial extensions |
-| `sample-metadata` | Sample descriptions, locations, notes, horizons, dimensions, and other sample-attached metadata entities |
+| `spatial` | Spatial context and coordinate-related entities such as `location`, `site_location`, `dimension`, and site, sample, or sample-group coordinate extensions |
+| `sample-metadata` | Sample and sample-group descriptions, locations, notes, horizons, dimensions, references, and other attached metadata entities |
 | `abundance` | Abundance observations, abundance property entities, and related classifiers |
 | `taxonomy` | Taxonomy entities such as `taxa_tree_master`, `taxa_common_names`, and taxonomy support lookups |
 | `dating` | Relative dating, chronology, dating lab, and uncertainty entities |

--- a/docs/proposals/CHANGE_REQUEST_INGESTER/DELIVERY_1_FOLLOWUP_ISSUES.md
+++ b/docs/proposals/CHANGE_REQUEST_INGESTER/DELIVERY_1_FOLLOWUP_ISSUES.md
@@ -193,7 +193,7 @@ Files:
 
 - `docs/proposals/SEAD_V2_TARGET_MODEL_COMPLETENESS.md`
 - `docs/proposals/CHANGE_REQUEST_INGESTER/DELIVERY_1_FOLLOWUP_CR.md`
-- `resources/target_models/sead_standard_model.yml`
+- `resources/target_models/sead_superset_model.yml`
 
 ## Issue 6 [docs(metadata): compare SEAD target model with SeadSchema live-schema approach](https://github.com/humlab-sead/sead_shape_shifter/issues/442)
 

--- a/docs/proposals/SEAD_V2_TARGET_MODEL_COMPLETENESS.md
+++ b/docs/proposals/SEAD_V2_TARGET_MODEL_COMPLETENESS.md
@@ -22,7 +22,7 @@ Current issue state on this branch:
 
 The previous completeness note was no longer reliable.
 
-It mixed historical expansion plans with current-state claims and overstated implemented coverage. A direct check against [resources/target_models/sead_standard_model.yml](../../resources/target_models/sead_standard_model.yml) shows a verified surface of 51 top-level entities in the current model, not the larger phase-based inventory described in the older draft.
+It mixed historical expansion plans with current-state claims and overstated implemented coverage. A direct check against [resources/target_models/sead_superset_model.yml](../../resources/target_models/sead_superset_model.yml) shows a verified surface of 51 top-level entities in the current model, not the larger phase-based inventory described in the older draft.
 
 Issue 5 should therefore be treated as a review and decision task first.
 
@@ -40,7 +40,7 @@ The filtered Issue 6 snapshots are still useful, but they are only one evidence 
 
 The current target model already covers a substantial core for Delivery 1 and early SEAD ingestion work.
 
-Verified entity surface in [resources/target_models/sead_standard_model.yml](../../resources/target_models/sead_standard_model.yml):
+Verified entity surface in [resources/target_models/sead_superset_model.yml](../../resources/target_models/sead_superset_model.yml):
 
 - Core and provenance: `location`, `location_type`, `site`, `site_location`, `sample_group`, `sample`, `method`, `dataset`, `master_dataset`, `project`, `citation`, `contact`, `contact_type`, `dataset_contact`
 - Sample and coordinate support: `sample_description_type`, `sample_description`, `sample_type`, `dimension`, `coordinate_method_dimension`, `sample_coordinate`, `alt_ref_type`, `sample_alt_ref`, `sample_dimension`
@@ -120,7 +120,7 @@ Issue 6 should not be tracked as a separate, context-free note.
 
 It depends directly on the same review work as Issue 5 because the practical question is not only "what is missing from the target model" but also "which schema concepts belong in the near-complete shared SEAD model and which are only operational artifacts".
 
-The current change-request ingester uses the target model in [resources/target_models/sead_standard_model.yml](../../resources/target_models/sead_standard_model.yml). The older `sead` ingester uses `SeadSchema` in [ingesters/sead/metadata.py](../../ingesters/sead/metadata.py), which derives metadata from the live SQL schema.
+The current change-request ingester uses the target model in [resources/target_models/sead_superset_model.yml](../../resources/target_models/sead_superset_model.yml). The older `sead` ingester uses `SeadSchema` in [ingesters/sead/metadata.py](../../ingesters/sead/metadata.py), which derives metadata from the live SQL schema.
 
 Before more follow-up work grows around the current metadata boundary, this document should make the tradeoffs between those two approaches explicit.
 
@@ -252,7 +252,7 @@ Current branch status: this step is initialized in [docs/proposals/CHANGE_REQUES
 2. Group the remaining live-schema tables into comparison buckets rather than reviewing them one by one.
 Use practical buckets such as core provenance, site and location, sample and sample group, feature context, chronology and dating, taxonomy, abundance, analysis values, project metadata, and lookup tables.
 
-3. Map each filtered live-schema bucket to the current target-model entities in [resources/target_models/sead_standard_model.yml](../../resources/target_models/sead_standard_model.yml).
+3. Map each filtered live-schema bucket to the current target-model entities in [resources/target_models/sead_superset_model.yml](../../resources/target_models/sead_superset_model.yml).
 For each bucket, record one of four outcomes: already covered, partially covered, missing from the target model, or intentionally out of scope for the shared model.
 
 4. Use [docs/proposals/CHANGE_REQUEST_INGESTER/filtered_import_columns.csv](./CHANGE_REQUEST_INGESTER/filtered_import_columns.csv) to check whether the apparent table-level gaps are real entity gaps or only column-level differences.
@@ -337,7 +337,7 @@ Issue 6 should be closed only when this document contains an explicit comparison
 
 The next steps should be:
 
-1. Keep [resources/target_models/sead_standard_model.yml](../../resources/target_models/sead_standard_model.yml) as the source of truth for current coverage.
+1. Keep [resources/target_models/sead_superset_model.yml](../../resources/target_models/sead_superset_model.yml) as the source of truth for current coverage.
 2. Use this document to track verified missing areas, verified decisions, and the intended completeness boundary for the shared SEAD model.
 3. Separate true shared-model entities from derived or operational schema artifacts before adding more entities.
 4. Keep the target model as the active metadata boundary for `sead_change_request` unless a later architecture proposal explicitly changes that decision.
@@ -486,7 +486,7 @@ Issue 6 should count as complete when all of the following are true:
 
 ## References
 
-- [resources/target_models/sead_standard_model.yml](../../resources/target_models/sead_standard_model.yml)
+- [resources/target_models/sead_superset_model.yml](../../resources/target_models/sead_superset_model.yml)
 - [docs/TARGET_MODEL_GUIDE.md](../TARGET_MODEL_GUIDE.md)
 - [ingesters/sead/metadata.py](../../ingesters/sead/metadata.py)
 - [docs/proposals/SEAD_V2_TARGET_MODEL_FOLLOWUP_ISSUES.md](./SEAD_V2_TARGET_MODEL_FOLLOWUP_ISSUES.md)

--- a/docs/proposals/SEAD_V2_TARGET_MODEL_COMPLETENESS.md
+++ b/docs/proposals/SEAD_V2_TARGET_MODEL_COMPLETENESS.md
@@ -15,14 +15,14 @@ This proposal now carries the detailed scope for these follow-up issues:
 
 Current issue state on this branch:
 
-- Issue 5: review structure improved on current branch, but not yet fully aligned to the SEAD-wide superset goal
+- Issue 5: reassessment decisions are now implemented on the current branch for the remaining shared-model candidates, and the branch also records which earlier candidates are out of scope for the shared SEAD superset
 - Issue 6: still open, but detailed analysis should now live in this document rather than in the change-request follow-up proposal
 
 ## Summary
 
 The previous completeness note was no longer reliable.
 
-It mixed historical expansion plans with current-state claims and overstated implemented coverage. A direct check against [resources/target_models/sead_superset_model.yml](../../resources/target_models/sead_superset_model.yml) shows a verified surface of 51 top-level entities in the current model, not the larger phase-based inventory described in the older draft.
+It mixed historical expansion plans with current-state claims and overstated implemented coverage. A direct check against [resources/target_models/sead_superset_model.yml](../../resources/target_models/sead_superset_model.yml) shows a verified surface of 61 top-level entities in the current model, not the larger phase-based inventory described in the older draft.
 
 Issue 5 should therefore be treated as a review and decision task first.
 
@@ -42,11 +42,11 @@ The current target model already covers a substantial core for Delivery 1 and ea
 
 Verified entity surface in [resources/target_models/sead_superset_model.yml](../../resources/target_models/sead_superset_model.yml):
 
-- Core and provenance: `location`, `location_type`, `site`, `site_location`, `sample_group`, `sample`, `method`, `dataset`, `master_dataset`, `project`, `citation`, `contact`, `contact_type`, `dataset_contact`
-- Sample and coordinate support: `sample_description_type`, `sample_description`, `sample_type`, `dimension`, `coordinate_method_dimension`, `sample_coordinate`, `alt_ref_type`, `sample_alt_ref`, `sample_dimension`
+- Core and provenance: `location`, `location_type`, `site`, `site_location`, `sample_group`, `sample`, `method`, `dataset`, `master_dataset`, `project`, `project_type`, `project_stage`, `citation`, `contact`, `contact_type`, `dataset_contact`
+- Sample and coordinate support: `sample_description_type`, `sample_description`, `sample_type`, `dimension`, `coordinate_method_dimension`, `coordinate_system`, `sample_coordinate`, `alt_ref_type`, `sample_alt_ref`, `sample_dimension`
 - Analysis and abundance: `analysis_entity`, `abundance`, `abundance_element`, `abundance_element_group`, `abundance_modification`, `modification_type`, `abundance_property`, `identification_level`, `abundance_ident_level`
 - Dating: `age_type`, `relative_age_type`, `chronology`, `dating_uncertainty`, `dating_material`, `relative_ages`, `relative_dating`, `geochronology`, `dating_lab`
-- Taxonomy and features: `taxa_tree_master`, `taxa_common_names`, `feature_type`, `feature`, `sample_feature`
+- Taxonomy and features: `taxa_tree_master`, `taxa_common_names`, `taxa_synonyms`, `taxa_measured_attributes`, `rdb_system`, `rdb_code`, `rdb`, `feature_type`, `feature`, `sample_feature`
 - Classification and measurement support: `method_group`, `data_type`, `unit`, `site_type_group`, `site_type`
 
 This is enough to support the current change-request work, but it is not yet a near-complete SEAD-wide target model.
@@ -75,18 +75,17 @@ Several entity families still appear to be missing from the current model and sh
 
 Verified missing candidates from the current YAML include:
 
-- Spatial and site-location support: `coordinate_system`, `sample_group_coordinate`, `site_natgridref`
-- Dating and period support: `dating_period`
+- Spatial and site-location support: `sample_group_coordinate`, `site_natgridref`
 - Feature and site metadata: `feature_property`, `feature_property_type`, `site_property`, `site_property_type`
-- Site-region support: `site_natural_region`, `natural_region`, `natural_region_group`
-- Sample metadata: `sample_horizon`, `sample_location`, `sample_location_type`, `sample_note`, `sample_colour`, `colour`
+- Sample metadata: `sample_horizon`, `sample_location`, `sample_location_type`, `sample_note`
 - Sample-group metadata: `sample_group_dimension`, `sample_group_note`, `sample_group_reference`
-- Taxon and ecology extensions: `taxon_synonyms`, `rdb`, `taxon_measured_attributes`
-- Abundance typing: `abundance_property_type`
 - Generic analysis values: `analysis_value`, `analysis_categorical_value`, `analysis_boolean_value`, `analysis_integer_value`, `analysis_numerical_value`, `analysis_date_range`, `analysis_note`, `analysis_identifier`
-- Project classification: `project_type`, `project_stage`
 
 This list is useful, but it still needs to be grouped into first-slice work, broader SEAD-wide follow-up, and derived or operational schema artifacts that do not need first-class target-model entities.
+
+The current branch has now resolved the earlier deferred shared-model candidates that survived review: `colour` and `sample_colour` are modeled explicitly, `project_type` plus `project_stage` are modeled as controlled vocabularies referenced by `project`, `coordinate_system` is kept in the shared superset, and the taxonomy and ecology slice is now modeled through `taxa_synonyms`, `taxa_measured_attributes`, `rdb_system`, `rdb_code`, and `rdb`.
+
+The branch also records two negative Issue 5 decisions: `dating_period` and `natural_region*` are treated as Arbodat-specific and are not being promoted into the shared SEAD target model.
 
 For Issue 5, keep this broader backlog visible.
 
@@ -98,9 +97,9 @@ On that narrower surface, the strongest first implementation slices are:
 - site and feature property patterns such as `site_natgridref`, `feature_property`, `feature_property_type`, `site_property`, and `site_property_type`
 - the generic analysis-value family such as `analysis_value`, typed analysis values, `analysis_note`, and `analysis_identifier`
 
-The current filtered snapshots do not support using `coordinate_system`, `dating_period`, `natural_region*`, `sample_colour`, `colour`, or `abundance_property_type` to close Issue 6.
+The current filtered snapshots do not support using `coordinate_system`, `dating_period`, `natural_region*`, `sample_colour`, or `colour` to close Issue 6.
 
-That does not mean those concepts are out of scope for the complete SEAD target model. It only means the filtered Issue 6 comparison should not be used as the sole justification for prioritizing them ahead of the current first slices.
+That does not mean all of those concepts belong in the same final category. On the current branch, the broader Issue 5 review keeps `coordinate_system` in the shared target model, while `dating_period` and `natural_region*` are treated as Arbodat-specific rather than shared SEAD-superset requirements.
 
 ### 3. Schema-Boundary Decisions
 
@@ -145,16 +144,16 @@ These gaps matter, but they should follow only after the high-priority spatial, 
 - `site_property`, `site_property_type`
 - `sample_note`
 - `sample_group_dimension`, `sample_group_note`, `sample_group_reference`
-- `taxon_synonyms`, `rdb`, `taxon_measured_attributes`
 
 ### Lower Priority Or Deferred
 
 These gaps remain part of the broader Issue 5 review, but the current filtered Issue 6 evidence does not justify using them as near-term closure items.
 
-- `project_type`, `project_stage`
-- `coordinate_system`, `dating_period`, `natural_region*`
-- `sample_colour`, `colour`, `abundance_property_type`
 - broader SEAD-wide concepts that should be scheduled after the first slices or clarified against the live schema before they are modeled
+
+`abundance_property_type` is no longer kept as a separate target-model candidate in this review. The live schema evidence on the current branch shows `abundance_property` already points to the shared `property_type` table, so a second abundance-only type entity would duplicate the now-implemented property pattern.
+
+`dating_period` and `natural_region*` are also no longer kept as shared-model backlog items in this review. They are treated as Arbodat-specific rather than as required parts of the near-complete SEAD superset.
 
 ## Target Model Versus `SeadSchema`
 
@@ -292,8 +291,8 @@ The current review should use these buckets.
 | Chronology and dating | `tbl_chronologies`, `tbl_geochronology`, `tbl_dating_labs`, `tbl_dating_material`, `tbl_dating_uncertainty`, `tbl_age_types`, `tbl_relative_age_types`, `tbl_relative_ages`, `tbl_relative_dates` | `chronology`, `geochronology`, `dating_lab`, `dating_material`, `dating_uncertainty`, `age_type`, `relative_age_type`, `relative_ages`, `relative_dating` | already covered | For Issue 6, this bucket mostly confirms current coverage. The earlier `dating_period` candidate is not supported by the filtered snapshot and should stay out of this review surface. |
 | Abundance and identification | `tbl_abundances`, `tbl_abundance_elements`, `tbl_abundance_modifications`, `tbl_modification_types`, `tbl_identification_levels`, `tbl_abundance_ident_levels`, `tbl_abundance_properties` | `abundance`, `abundance_element`, `abundance_modification`, `modification_type`, `identification_level`, `abundance_ident_level`, `abundance_property` | already covered | This bucket mostly validates the current abundance model. The remaining question is whether the shared property-type surface should later be modeled more explicitly. |
 | Analysis values and typed value families | `tbl_analysis_entities`, `tbl_analysis_values`, `tbl_analysis_boolean_values`, `tbl_analysis_categorical_values`, `tbl_analysis_integer_values`, `tbl_analysis_numerical_values`, `tbl_analysis_dating_ranges`, `tbl_analysis_notes`, `tbl_analysis_identifiers`, `tbl_analysis_value_dimensions`, `tbl_analysis_taxon_counts` | `analysis_entity` exists; the generic analysis-value family does not | partially covered | This is the clearest model gap in the filtered snapshots and the strongest candidate for future target-model growth after the current review closes. |
-| Taxonomy and ecology extensions | `tbl_taxa_common_names`, `tbl_taxa_synonyms`, `tbl_taxa_measured_attributes`, `tbl_rdb`, `tbl_rdb_codes`, `tbl_rdb_systems`, `tbl_ecocodes`, `tbl_ecocode_groups`, `tbl_ecocode_systems` | `taxa_tree_master`, `taxa_common_names`; no direct entities for the wider enrichment surface | partially covered | The filtered tables show a real SEAD-wide enrichment surface, but it still looks better suited to a later shared-model slice than to the current first implementation tranche. |
-| Project classification and support lookups | `tbl_project_types`, `tbl_project_stages` plus broad support tables such as `tbl_activity_types`, `tbl_record_types`, `tbl_languages`, `tbl_seasons` | `project` already carries project-type and project-stage fields; most support lookups have no direct entity need in the current model | partially covered | This bucket should stay conservative. `project_type` and `project_stage` may justify future controlled-vocabulary entities, but the current evidence does not force them into the core model now. |
+| Taxonomy and ecology extensions | `tbl_taxa_common_names`, `tbl_taxa_synonyms`, `tbl_taxa_measured_attributes`, `tbl_rdb`, `tbl_rdb_codes`, `tbl_rdb_systems`, `tbl_ecocodes`, `tbl_ecocode_groups`, `tbl_ecocode_systems` | `taxa_tree_master`, `taxa_common_names`, `taxa_synonyms`, `taxa_measured_attributes`, `rdb_system`, `rdb_code`, and `rdb`; the ecocode family is still outside the current model | partially covered | The branch now models the main taxonomy and Red Data Book slice as shared SEAD concepts, while the wider ecocode surface stays outside the current implementation boundary. |
+| Project classification and support lookups | `tbl_project_types`, `tbl_project_stages` plus broad support tables such as `tbl_activity_types`, `tbl_record_types`, `tbl_languages`, `tbl_seasons` | `project`, `project_type`, and `project_stage`; most support lookups still have no direct entity need in the current model | already covered | The project classification lookups are now modeled explicitly, while the broader support-table surface can stay outside the current target-model boundary until it has clearer shared-model value. |
 
 ### Done Condition For This Plan
 
@@ -320,13 +319,13 @@ It uses the filtered `get_sead_tables()` and `get_sead_columns()` outputs in [do
 | Sample and sample-group context extensions | `tbl_sample_horizons`, `tbl_sample_notes` | `sample`, `sample_description`, and `sample_dimension` exist, but these sample-context concepts are not modeled explicitly | candidate target-model addition | These are active imported tables that add material sample context beyond the current generic description coverage. |
 | Sample and sample-group context extensions | `tbl_sample_group_dimensions`, `tbl_sample_group_notes`, `tbl_sample_group_references` | `sample_group` exists, but the grouped-dimension, note, and reference surfaces are absent | candidate target-model addition | These are active imported concepts in the filtered CSV set and are a better fit for grouped sampling context than ad hoc free-text extensions. |
 | Feature context and generic properties | `tbl_feature_properties`, `tbl_site_properties`, with shared lookup support from `tbl_property_types` | `feature` and `site` exist, but the generic property pattern is not modeled in the current target model | candidate target-model addition | The column snapshots show a consistent property pattern built from `property_type_id` plus `property_value`, which makes this a reusable active concept rather than a one-off legacy table. |
-| Project classification and support lookups | `tbl_project_types`, `tbl_project_stages` | `project` already carries `project_type_id` and `project_stage_id` columns, but no dedicated lookup entities are modeled | keep in target model | The concept is already represented at the `project` entity boundary. Dedicated lookup entities can stay deferred unless validation or reconciliation needs controlled-vocabulary modeling. |
-| Taxonomy and ecology extensions | `tbl_taxa_synonyms`, `tbl_taxa_measured_attributes`, `tbl_rdb`, `tbl_rdb_codes`, `tbl_rdb_systems` | `taxa_tree_master` and `taxa_common_names` exist, but these enrichment tables are not modeled | later shared-model candidate | These tables are present in the filtered import set and may belong in the broader SEAD target model, but they are not the best first slice for the current implementation order. |
+| Project classification and support lookups | `tbl_project_types`, `tbl_project_stages` | `project_type` and `project_stage` are now modeled explicitly and linked from `project` | keep in target model | The branch now models these controlled vocabularies directly, which removes them from the deferred lookup backlog for the shared SEAD superset. |
+| Taxonomy and ecology extensions | `tbl_taxa_synonyms`, `tbl_taxa_measured_attributes`, `tbl_rdb`, `tbl_rdb_codes`, `tbl_rdb_systems` | `taxa_synonyms`, `taxa_measured_attributes`, `rdb_system`, `rdb_code`, and `rdb` are now modeled explicitly | keep in target model | The current branch now treats this taxonomy and Red Data Book slice as part of the shared SEAD superset rather than as a deferred extension candidate. |
 | Excluded review surface | `tbl_image_types`, `tbl_colours`, `tbl_sample_colours`, `tbl_aggregate_datasets`, `tbl_aggregate_order_types`, `tbl_aggregate_sample_ages`, `tbl_aggregate_samples` | Present in the raw CSV snapshots, but explicitly excluded from the Issue 6 review surface | ignore for Issue 6 | These tables are intentionally outside the current target-model boundary review for `sead_change_request`. |
 | Excluded review surface | `tbl_ceramic*`, `tbl_isotope*`, `tbl_dendro*` | Present in the raw CSV snapshots, but explicitly excluded from the Issue 6 review surface | ignore for Issue 6 | These families are superseded by the `tbl_analysis_values` path and should not drive new target-model decisions. |
 | Excluded review surface | `tbl_mcr*` | Present in the raw CSV snapshots, but explicitly excluded from the Issue 6 review surface | ignore for Issue 6 | These are live derived tables rather than imported source tables. |
 | Excluded review surface | `tbl*_images` | Present in the raw CSV snapshots, but explicitly excluded from the Issue 6 review surface | ignore for Issue 6 | Image tables are not imported in the current scope. |
-| Lower Priority Or Deferred | Candidate families mentioned earlier in this proposal but not present in the filtered CSV snapshots, including `coordinate_system`, `dating_period`, and `natural_region*` | Not modeled explicitly in the current target model and not evidenced by the current import snapshots | ignore for Issue 6 | They may still matter later for Issue 5, but they are not supported by the current offline `SeadSchema` baseline and should not be used to close or broaden Issue 6 now. |
+| Lower Priority Or Deferred | Candidate families mentioned earlier in this proposal but not present in the filtered CSV snapshots, including `coordinate_system`, `dating_period`, and `natural_region*` | `coordinate_system` is now modeled explicitly; `dating_period` and `natural_region*` are intentionally out of scope for the shared superset | ignore for Issue 6 | The filtered offline baseline still does not support using these concepts to close or broaden Issue 6, even though the broader Issue 5 review now keeps `coordinate_system` and rejects the Arbodat-specific candidates. |
 
 ## Recommendation
 
@@ -405,13 +404,14 @@ Tracked by [#451](https://github.com/humlab-sead/sead_shape_shifter/issues/451).
 
 Use a separate pass for the broader SEAD-wide backlog that does not fit cleanly into the first implementation rounds.
 
-This pass should keep the first slices narrow while still acknowledging the wider completeness target:
+The current branch has already completed that pass for the shared-model candidates that remained after review by promoting `colour`, `sample_colour`, `project_type`, `project_stage`, `coordinate_system`, `taxa_synonyms`, `taxa_measured_attributes`, `rdb_system`, `rdb_code`, and `rdb`.
 
-- `project_type`, `project_stage`
-- `taxon_synonyms`, `rdb`, `taxon_measured_attributes`
-- `coordinate_system`, `dating_period`, `natural_region*`
-- `sample_colour`, `colour`, `abundance_property_type`
-- broader SEAD-wide backlog items not covered by the current first slices
+This pass also records which earlier candidates are not part of the shared superset:
+
+- `dating_period`
+- `natural_region*`
+
+The branch also treats `abundance_property_type` as subsumed by the shared `property_type` entity rather than as a separate remaining lookup family.
 
 ## Implementation Handoff
 
@@ -435,7 +435,7 @@ Use these slices as the default first breakdown.
 | 2 | [#448 feat(target_model): add sample-group context entities](https://github.com/humlab-sead/sead_shape_shifter/issues/448) | `sample_group_coordinate`, `sample_group_dimension`, `sample_group_note`, `sample_group_reference` | site and feature properties, analysis-value work, later SEAD-wide backlog slices | The shared target model can represent grouped sampling context with explicit entities tied to `sample_group`. |
 | 3 | [#449 feat(target_model): add site and feature property entities](https://github.com/humlab-sead/sead_shape_shifter/issues/449) | `feature_property_type`, `feature_property`, `site_property_type`, `site_property`, `site_natgridref` | sample-context entities already covered by earlier slices, analysis-value work | The shared target model has an explicit reusable property pattern for important site and feature metadata that is still missing from the current YAML. |
 | 4 | [#450 feat(target_model): design generic analysis-value family](https://github.com/humlab-sead/sead_shape_shifter/issues/450) | `analysis_value`, `analysis_note`, `analysis_identifier`, typed analysis-value variants | derived method-specific artifacts, project-only subset choices | The shared target model has an agreed shape for generic typed analysis values that can support multiple SEAD data families without forcing provider-specific assumptions into the model. |
-| 5 | [#451 proposal(target_model): reassess deferred lookup and extension candidates](https://github.com/humlab-sead/sead_shape_shifter/issues/451) | `project_type`, `project_stage`, `taxon_synonyms`, `rdb`, `taxon_measured_attributes`, plus broader backlog candidates such as `coordinate_system`, `dating_period`, `natural_region*`, `sample_colour`, `colour`, and `abundance_property_type` | derived tables, operational-only columns, and project-level subset decisions that do not belong in the shared model definition | A separate decision confirms which remaining SEAD-wide concepts need promotion into the near-complete shared target model and which schema surfaces are only operational artifacts. |
+| 5 | [#451 proposal(target_model): reassess deferred lookup and extension candidates](https://github.com/humlab-sead/sead_shape_shifter/issues/451) | promote shared candidates such as `coordinate_system`, `taxa_synonyms`, `taxa_measured_attributes`, `rdb`, `rdb_code`, and `rdb_system`; reject Arbodat-specific candidates such as `dating_period` and `natural_region*`; keep abundance properties on the shared `property_type` model | unrelated project-level subset choices and operational-only schema artifacts | The review is done when the branch both promotes the remaining shared SEAD candidates and records which earlier lookup candidates do not belong in the shared superset. |
 
 These issue slices are intentionally narrow.
 

--- a/docs/proposals/SEAD_V2_TARGET_MODEL_COMPLETENESS.md
+++ b/docs/proposals/SEAD_V2_TARGET_MODEL_COMPLETENESS.md
@@ -3,8 +3,8 @@
 ## Status
 
 - Current state: rewritten against the current target model
-- Scope: classify remaining SEAD v2 target-model gaps and document the metadata-boundary comparison with `SeadSchema`
-- Decision goal: identify what is missing in documentation, what is missing in the model, and what should remain target-model-driven versus schema-driven before more model growth
+- Scope: classify remaining SEAD v2 target-model gaps, define the intended completeness boundary for the shared SEAD model, and document the metadata-boundary comparison with `SeadSchema`
+- Decision goal: define a near-complete, provider-independent SEAD target model while keeping project-specific Shape Shifter configurations as curated subsets of that larger model
 
 ## Tracked Issues
 
@@ -15,7 +15,7 @@ This proposal now carries the detailed scope for these follow-up issues:
 
 Current issue state on this branch:
 
-- Issue 5: resolved on current branch
+- Issue 5: review structure improved on current branch, but not yet fully aligned to the SEAD-wide superset goal
 - Issue 6: still open, but detailed analysis should now live in this document rather than in the change-request follow-up proposal
 
 ## Summary
@@ -26,7 +26,15 @@ It mixed historical expansion plans with current-state claims and overstated imp
 
 Issue 5 should therefore be treated as a review and decision task first.
 
-The immediate job is not to add more entities blindly. It is to produce a usable gap classification so later model edits are driven by real SEAD workflows rather than by an outdated wish list.
+The immediate job is not to narrow the model to one provider, one project, or one import slice. It is to produce a usable completeness review so later model edits are driven by the current SEAD schema surface and by shared SEAD concepts rather than by an outdated wish list.
+
+The intended target is a close-to-complete SEAD target model.
+
+That shared model should contain almost all current SEAD tables and concepts, independent of any one data provider or data type.
+
+Individual Shape Shifter projects can then use manually curated subsets of that larger target model.
+
+The filtered Issue 6 snapshots are still useful, but they are only one evidence source for the metadata-boundary comparison. They are not the full completeness boundary for the SEAD target model.
 
 ## Verified Current Coverage
 
@@ -41,7 +49,7 @@ Verified entity surface in [resources/target_models/sead_standard_model.yml](../
 - Taxonomy and features: `taxa_tree_master`, `taxa_common_names`, `feature_type`, `feature`, `sample_feature`
 - Classification and measurement support: `method_group`, `data_type`, `unit`, `site_type_group`, `site_type`
 
-This is enough to support the current change-request work, but it is not yet a complete SEAD v2 target-model review.
+This is enough to support the current change-request work, but it is not yet a near-complete SEAD-wide target model.
 
 ## Problem
 
@@ -58,6 +66,8 @@ Examples:
 - it mixed implementation status, Arbodat-specific needs, and general SEAD backlog into one inventory
 
 That makes it hard to tell whether a gap is real, already solved, or only proposed.
+
+It also makes it hard to tell whether the document is describing the shared SEAD target model or only one project's current subset.
 
 ### 2. Target-Model Gaps
 
@@ -76,13 +86,13 @@ Verified missing candidates from the current YAML include:
 - Generic analysis values: `analysis_value`, `analysis_categorical_value`, `analysis_boolean_value`, `analysis_integer_value`, `analysis_numerical_value`, `analysis_date_range`, `analysis_note`, `analysis_identifier`
 - Project classification: `project_type`, `project_stage`
 
-This list is useful, but it is still only a candidate backlog until each item is tied to an actual validation or ingestion need.
+This list is useful, but it still needs to be grouped into first-slice work, broader SEAD-wide follow-up, and derived or operational schema artifacts that do not need first-class target-model entities.
 
 For Issue 5, keep this broader backlog visible.
 
-For Issue 6, use the filtered `SeadSchema` snapshots as the narrower evidence surface.
+For Issue 6, use the filtered `SeadSchema` snapshots as one narrower evidence surface for the metadata-boundary comparison.
 
-On that narrower surface, the strongest supported follow-up areas are:
+On that narrower surface, the strongest first implementation slices are:
 
 - sample and sample-group context additions such as `sample_group_coordinate`, `sample_horizon`, `sample_location`, `sample_location_type`, `sample_note`, `sample_group_dimension`, `sample_group_note`, and `sample_group_reference`
 - site and feature property patterns such as `site_natgridref`, `feature_property`, `feature_property_type`, `site_property`, and `site_property_type`
@@ -90,15 +100,17 @@ On that narrower surface, the strongest supported follow-up areas are:
 
 The current filtered snapshots do not support using `coordinate_system`, `dating_period`, `natural_region*`, `sample_colour`, `colour`, or `abundance_property_type` to close Issue 6.
 
+That does not mean those concepts are out of scope for the complete SEAD target model. It only means the filtered Issue 6 comparison should not be used as the sole justification for prioritizing them ahead of the current first slices.
+
 ### 3. Schema-Boundary Decisions
 
-Some gaps may not belong in the core SEAD target model at all.
+Some gaps may still need special handling, but the default assumption should now be inclusion in the shared SEAD target model unless there is a strong reason to classify the schema surface as derived, operational, or non-domain metadata.
 
-Examples called out in earlier work include `natural_region`, `cultural_group`, `archaeological_period`, and related region-specific or project-specific concepts. Those may be:
+Examples called out in earlier work include `natural_region`, `cultural_group`, `archaeological_period`, and related region-specific concepts. Those may be:
 
 - real core SEAD gaps
-- valid extension-model concerns
-- data-project conveniences that should not be promoted into the shared target model yet
+- broad shared-model concerns that should be scheduled later rather than discarded
+- derived or operational schema concerns that should not be promoted into the shared target model as first-class entities
 
 Issue 5 is not complete until those categories are separated explicitly.
 
@@ -106,7 +118,7 @@ Issue 5 is not complete until those categories are separated explicitly.
 
 Issue 6 should not be tracked as a separate, context-free note.
 
-It depends directly on the same review work as Issue 5 because the practical question is not only "what is missing from the target model" but also "what should be modeled here at all".
+It depends directly on the same review work as Issue 5 because the practical question is not only "what is missing from the target model" but also "which schema concepts belong in the near-complete shared SEAD model and which are only operational artifacts".
 
 The current change-request ingester uses the target model in [resources/target_models/sead_standard_model.yml](../../resources/target_models/sead_standard_model.yml). The older `sead` ingester uses `SeadSchema` in [ingesters/sead/metadata.py](../../ingesters/sead/metadata.py), which derives metadata from the live SQL schema.
 
@@ -142,7 +154,7 @@ These gaps remain part of the broader Issue 5 review, but the current filtered I
 - `project_type`, `project_stage`
 - `coordinate_system`, `dating_period`, `natural_region*`
 - `sample_colour`, `colour`, `abundance_property_type`
-- extension-like concepts that may belong outside the shared core model until their reuse is proven
+- broader SEAD-wide concepts that should be scheduled after the first slices or clarified against the live schema before they are modeled
 
 ## Target Model Versus `SeadSchema`
 
@@ -246,8 +258,8 @@ For each bucket, record one of four outcomes: already covered, partially covered
 4. Use [docs/proposals/CHANGE_REQUEST_INGESTER/filtered_import_columns.csv](./CHANGE_REQUEST_INGESTER/filtered_import_columns.csv) to check whether the apparent table-level gaps are real entity gaps or only column-level differences.
 Do not propose a new target-model entity until the filtered column snapshot shows that the live-schema table carries a distinct business concept rather than only extra operational columns such as legacy XML names or analysis-value-specific structure.
 
-5. Separate true core-model candidates from extension or legacy candidates.
-If a missing concept only exists in deprecated table families, only exists in derived tables, or is tightly tied to a legacy method-specific structure, keep it out of the core target-model gap list.
+5. Separate true shared-model candidates from derived, operational, or legacy-only schema artifacts.
+If a missing concept only exists in deprecated table families, only exists in derived tables, or is tightly tied to a legacy method-specific structure, keep it out of the shared target-model gap list.
 
 6. Rewrite the current candidate-gap lists in this document against the filtered CSV evidence.
 Promote only those gaps that still survive the deprecated-table filter and that map to an active imported concept in the remaining live-schema set.
@@ -256,7 +268,7 @@ Promote only those gaps that still survive the deprecated-table filter and that 
 State that the comparison was performed against filtered offline snapshots of `get_sead_tables()` and `get_sead_columns()`, not against an unfiltered live schema dump.
 
 8. Produce a short decision table in this document for the remaining open Issue 6 scope.
-Each row should name the live-schema concept or table family, the matching target-model entity if one exists, the decision (`keep in target model`, `candidate target-model addition`, `extension candidate`, or `ignore for Issue 6`), and a one-line reason.
+Each row should name the live-schema concept or table family, the matching target-model entity if one exists, the decision (`keep in target model`, `candidate target-model addition`, `later shared-model candidate`, or `ignore for Issue 6`), and a one-line reason.
 
 9. Close Issue 6 only after the document contains both parts of the final outcome.
 The first part is the filtered comparison method. The second part is a decision-ready list of the live-schema concepts that still justify target-model follow-up.
@@ -280,7 +292,7 @@ The current review should use these buckets.
 | Chronology and dating | `tbl_chronologies`, `tbl_geochronology`, `tbl_dating_labs`, `tbl_dating_material`, `tbl_dating_uncertainty`, `tbl_age_types`, `tbl_relative_age_types`, `tbl_relative_ages`, `tbl_relative_dates` | `chronology`, `geochronology`, `dating_lab`, `dating_material`, `dating_uncertainty`, `age_type`, `relative_age_type`, `relative_ages`, `relative_dating` | already covered | For Issue 6, this bucket mostly confirms current coverage. The earlier `dating_period` candidate is not supported by the filtered snapshot and should stay out of this review surface. |
 | Abundance and identification | `tbl_abundances`, `tbl_abundance_elements`, `tbl_abundance_modifications`, `tbl_modification_types`, `tbl_identification_levels`, `tbl_abundance_ident_levels`, `tbl_abundance_properties` | `abundance`, `abundance_element`, `abundance_modification`, `modification_type`, `identification_level`, `abundance_ident_level`, `abundance_property` | already covered | This bucket mostly validates the current abundance model. The remaining question is whether the shared property-type surface should later be modeled more explicitly. |
 | Analysis values and typed value families | `tbl_analysis_entities`, `tbl_analysis_values`, `tbl_analysis_boolean_values`, `tbl_analysis_categorical_values`, `tbl_analysis_integer_values`, `tbl_analysis_numerical_values`, `tbl_analysis_dating_ranges`, `tbl_analysis_notes`, `tbl_analysis_identifiers`, `tbl_analysis_value_dimensions`, `tbl_analysis_taxon_counts` | `analysis_entity` exists; the generic analysis-value family does not | partially covered | This is the clearest model gap in the filtered snapshots and the strongest candidate for future target-model growth after the current review closes. |
-| Taxonomy and ecology extensions | `tbl_taxa_common_names`, `tbl_taxa_synonyms`, `tbl_taxa_measured_attributes`, `tbl_rdb`, `tbl_rdb_codes`, `tbl_rdb_systems`, `tbl_ecocodes`, `tbl_ecocode_groups`, `tbl_ecocode_systems` | `taxa_tree_master`, `taxa_common_names`; no direct entities for the wider enrichment surface | partially covered | The filtered tables show a real extension surface, but it still looks more like enrichment and specialist context than core metadata required for current change-request planning. |
+| Taxonomy and ecology extensions | `tbl_taxa_common_names`, `tbl_taxa_synonyms`, `tbl_taxa_measured_attributes`, `tbl_rdb`, `tbl_rdb_codes`, `tbl_rdb_systems`, `tbl_ecocodes`, `tbl_ecocode_groups`, `tbl_ecocode_systems` | `taxa_tree_master`, `taxa_common_names`; no direct entities for the wider enrichment surface | partially covered | The filtered tables show a real SEAD-wide enrichment surface, but it still looks better suited to a later shared-model slice than to the current first implementation tranche. |
 | Project classification and support lookups | `tbl_project_types`, `tbl_project_stages` plus broad support tables such as `tbl_activity_types`, `tbl_record_types`, `tbl_languages`, `tbl_seasons` | `project` already carries project-type and project-stage fields; most support lookups have no direct entity need in the current model | partially covered | This bucket should stay conservative. `project_type` and `project_stage` may justify future controlled-vocabulary entities, but the current evidence does not force them into the core model now. |
 
 ### Done Condition For This Plan
@@ -292,7 +304,7 @@ Issue 6 is ready to close when this document makes all of the following explicit
 - `tbl_image_types`, `tbl_colours`, `tbl_sample_colours`, `tbl_aggregate_datasets`, `tbl_aggregate_order_types`, `tbl_aggregate_sample_ages`, and `tbl_aggregate_samples` were also excluded from the Issue 6 review surface
 - `date_updated` was excluded from the column-level review surface
 - the remaining live-schema concepts were mapped against the current target model
-- the document clearly separates core-model follow-up from legacy, derived, or extension-only candidates
+- the document clearly separates shared-model follow-up from legacy, derived, or operational-only schema artifacts
 - the final recommendation still keeps the target model as the active metadata boundary for `sead_change_request`
 
 ## Issue 6 Decision Table
@@ -309,7 +321,7 @@ It uses the filtered `get_sead_tables()` and `get_sead_columns()` outputs in [do
 | Sample and sample-group context extensions | `tbl_sample_group_dimensions`, `tbl_sample_group_notes`, `tbl_sample_group_references` | `sample_group` exists, but the grouped-dimension, note, and reference surfaces are absent | candidate target-model addition | These are active imported concepts in the filtered CSV set and are a better fit for grouped sampling context than ad hoc free-text extensions. |
 | Feature context and generic properties | `tbl_feature_properties`, `tbl_site_properties`, with shared lookup support from `tbl_property_types` | `feature` and `site` exist, but the generic property pattern is not modeled in the current target model | candidate target-model addition | The column snapshots show a consistent property pattern built from `property_type_id` plus `property_value`, which makes this a reusable active concept rather than a one-off legacy table. |
 | Project classification and support lookups | `tbl_project_types`, `tbl_project_stages` | `project` already carries `project_type_id` and `project_stage_id` columns, but no dedicated lookup entities are modeled | keep in target model | The concept is already represented at the `project` entity boundary. Dedicated lookup entities can stay deferred unless validation or reconciliation needs controlled-vocabulary modeling. |
-| Taxonomy and ecology extensions | `tbl_taxa_synonyms`, `tbl_taxa_measured_attributes`, `tbl_rdb`, `tbl_rdb_codes`, `tbl_rdb_systems` | `taxa_tree_master` and `taxa_common_names` exist, but these enrichment tables are not modeled | extension candidate | These tables are present in the filtered import set, but they look like taxonomy and ecology enrichment rather than core metadata needed for current `sead_change_request` planning. |
+| Taxonomy and ecology extensions | `tbl_taxa_synonyms`, `tbl_taxa_measured_attributes`, `tbl_rdb`, `tbl_rdb_codes`, `tbl_rdb_systems` | `taxa_tree_master` and `taxa_common_names` exist, but these enrichment tables are not modeled | later shared-model candidate | These tables are present in the filtered import set and may belong in the broader SEAD target model, but they are not the best first slice for the current implementation order. |
 | Excluded review surface | `tbl_image_types`, `tbl_colours`, `tbl_sample_colours`, `tbl_aggregate_datasets`, `tbl_aggregate_order_types`, `tbl_aggregate_sample_ages`, `tbl_aggregate_samples` | Present in the raw CSV snapshots, but explicitly excluded from the Issue 6 review surface | ignore for Issue 6 | These tables are intentionally outside the current target-model boundary review for `sead_change_request`. |
 | Excluded review surface | `tbl_ceramic*`, `tbl_isotope*`, `tbl_dendro*` | Present in the raw CSV snapshots, but explicitly excluded from the Issue 6 review surface | ignore for Issue 6 | These families are superseded by the `tbl_analysis_values` path and should not drive new target-model decisions. |
 | Excluded review surface | `tbl_mcr*` | Present in the raw CSV snapshots, but explicitly excluded from the Issue 6 review surface | ignore for Issue 6 | These are live derived tables rather than imported source tables. |
@@ -326,20 +338,22 @@ Issue 6 should be closed only when this document contains an explicit comparison
 The next steps should be:
 
 1. Keep [resources/target_models/sead_standard_model.yml](../../resources/target_models/sead_standard_model.yml) as the source of truth for current coverage.
-2. Use this document to track only verified missing areas and verified decisions.
-3. Separate core-model gaps from extension-model candidates before adding more entities.
+2. Use this document to track verified missing areas, verified decisions, and the intended completeness boundary for the shared SEAD model.
+3. Separate true shared-model entities from derived or operational schema artifacts before adding more entities.
 4. Keep the target model as the active metadata boundary for `sead_change_request` unless a later architecture proposal explicitly changes that decision.
-5. Promote only the highest-value missing entities into implementation work.
+5. Promote the highest-value missing entities into implementation work first without shrinking the broader SEAD-wide completeness backlog to one project's current scope.
 
 ## Recommended Follow-Up Order
 
 If follow-up implementation work starts after this review, it should proceed in small slices ordered by change size and reuse value.
 
+These slices are the first tranche of work toward the near-complete SEAD target model. They are not the full completeness inventory.
+
 ### 1. Sample And Sample-Group Context First
 
 Tracked by [#447](https://github.com/humlab-sead/sead_shape_shifter/issues/447) and [#448](https://github.com/humlab-sead/sead_shape_shifter/issues/448).
 
-Start with the sample and sample-group context additions that are clearly supported by the filtered review surface and fit the existing model shape.
+Start with the sample and sample-group context additions that are both clearly supported by the filtered review surface and broadly aligned with the SEAD-wide shared model.
 
 Suggested first slice:
 
@@ -389,13 +403,15 @@ This slice likely has the highest design impact because it affects how the targe
 
 Tracked by [#451](https://github.com/humlab-sead/sead_shape_shifter/issues/451).
 
-Do not mix the more extension-like or controlled-vocabulary-driven candidates into the first implementation rounds.
+Use a separate pass for the broader SEAD-wide backlog that does not fit cleanly into the first implementation rounds.
 
-Keep these deferred unless a concrete validation or ingestion use case forces them forward:
+This pass should keep the first slices narrow while still acknowledging the wider completeness target:
 
 - `project_type`, `project_stage`
 - `taxon_synonyms`, `rdb`, `taxon_measured_attributes`
-- broader Issue 5 backlog items not supported by the filtered Issue 6 surface
+- `coordinate_system`, `dating_period`, `natural_region*`
+- `sample_colour`, `colour`, `abundance_property_type`
+- broader SEAD-wide backlog items not covered by the current first slices
 
 ## Implementation Handoff
 
@@ -403,26 +419,27 @@ When this proposal is used to start model work, each follow-up change should:
 
 - name the exact target-model entities being added
 - cite which Issue 6 bucket and decision-table row justified the change
+- state whether the slice is part of the shared SEAD superset or only a project-level subset decision
 - avoid mixing one bucket's work with another unless the model shape requires it
-- keep deferred and extension-candidate concepts out of the same change set
+- keep derived or operational schema artifacts out of the same change set
 
 ## Suggested Issue Slices
 
 The follow-up order above can be turned into small tracked issues without reopening the full review.
 
-Use these slices as the default breakdown.
+Use these slices as the default first breakdown.
 
 | Order | Suggested issue title | Target-model scope | Keep out of scope | Done signal |
 | --- | --- | --- | --- | --- |
-| 1 | [#447 feat(target_model): add sample-context entities](https://github.com/humlab-sead/sead_shape_shifter/issues/447) | `sample_horizon`, `sample_location`, `sample_location_type`, `sample_note` | property-pattern work, analysis-value work, taxonomy extensions | The target model can represent the main sample-context tables from the filtered review surface without reusing ad hoc free-text placeholders. |
-| 2 | [#448 feat(target_model): add sample-group context entities](https://github.com/humlab-sead/sead_shape_shifter/issues/448) | `sample_group_coordinate`, `sample_group_dimension`, `sample_group_note`, `sample_group_reference` | site and feature properties, analysis-value work, deferred lookups | The target model can represent grouped sampling context from the filtered review surface with explicit entities tied to `sample_group`. |
-| 3 | [#449 feat(target_model): add site and feature property entities](https://github.com/humlab-sead/sead_shape_shifter/issues/449) | `feature_property_type`, `feature_property`, `site_property_type`, `site_property`, `site_natgridref` | sample-context entities already covered by earlier slices, analysis-value work | The target model has an explicit reusable property pattern for the active site and feature metadata still missing from the filtered review surface. |
-| 4 | [#450 feat(target_model): design generic analysis-value family](https://github.com/humlab-sead/sead_shape_shifter/issues/450) | `analysis_value`, `analysis_note`, `analysis_identifier`, typed analysis-value variants | extension candidates, project lookup entities, unsupported Issue 6 backlog items | The target model has an agreed shape for generic typed analysis values that can replace method-specific assumptions without forcing unrelated extensions into the same change. |
-| 5 | [#451 proposal(target_model): reassess deferred lookup and extension candidates](https://github.com/humlab-sead/sead_shape_shifter/issues/451) | `project_type`, `project_stage`, `taxon_synonyms`, `rdb`, `taxon_measured_attributes` only if justified by concrete use cases | unsupported Issue 6 backlog such as `coordinate_system`, `dating_period`, `natural_region*`, `sample_colour`, `colour`, `abundance_property_type` unless new evidence appears | A separate decision confirms which deferred concepts need core-model promotion and which should remain extension candidates or broader Issue 5 backlog. |
+| 1 | [#447 feat(target_model): add sample-context entities](https://github.com/humlab-sead/sead_shape_shifter/issues/447) | `sample_horizon`, `sample_location`, `sample_location_type`, `sample_note` | property-pattern work, analysis-value work, later SEAD-wide backlog slices | The shared target model can represent a major sample-context surface cleanly as part of the broader SEAD superset. |
+| 2 | [#448 feat(target_model): add sample-group context entities](https://github.com/humlab-sead/sead_shape_shifter/issues/448) | `sample_group_coordinate`, `sample_group_dimension`, `sample_group_note`, `sample_group_reference` | site and feature properties, analysis-value work, later SEAD-wide backlog slices | The shared target model can represent grouped sampling context with explicit entities tied to `sample_group`. |
+| 3 | [#449 feat(target_model): add site and feature property entities](https://github.com/humlab-sead/sead_shape_shifter/issues/449) | `feature_property_type`, `feature_property`, `site_property_type`, `site_property`, `site_natgridref` | sample-context entities already covered by earlier slices, analysis-value work | The shared target model has an explicit reusable property pattern for important site and feature metadata that is still missing from the current YAML. |
+| 4 | [#450 feat(target_model): design generic analysis-value family](https://github.com/humlab-sead/sead_shape_shifter/issues/450) | `analysis_value`, `analysis_note`, `analysis_identifier`, typed analysis-value variants | derived method-specific artifacts, project-only subset choices | The shared target model has an agreed shape for generic typed analysis values that can support multiple SEAD data families without forcing provider-specific assumptions into the model. |
+| 5 | [#451 proposal(target_model): reassess deferred lookup and extension candidates](https://github.com/humlab-sead/sead_shape_shifter/issues/451) | `project_type`, `project_stage`, `taxon_synonyms`, `rdb`, `taxon_measured_attributes`, plus broader backlog candidates such as `coordinate_system`, `dating_period`, `natural_region*`, `sample_colour`, `colour`, and `abundance_property_type` | derived tables, operational-only columns, and project-level subset decisions that do not belong in the shared model definition | A separate decision confirms which remaining SEAD-wide concepts need promotion into the near-complete shared target model and which schema surfaces are only operational artifacts. |
 
 These issue slices are intentionally narrow.
 
-They preserve the main review decision from Issue 6: start with the entities that are both supported by the filtered snapshots and closest to the existing target-model shape.
+They preserve the main review decision from Issue 6: use the filtered snapshots to sequence the first slices without treating that comparison surface as the full boundary of the SEAD target model.
 
 ## Implementation Plan Table
 
@@ -434,7 +451,7 @@ If this proposal is used as the handoff document for execution, the implementati
 | Phase 2 | Sample-group context | Extends the same part of the model while keeping the pattern simple | Splitting group-level versus sample-level concepts inconsistently |
 | Phase 3 | Site and feature properties | Introduces a reusable pattern after simpler context entities are settled | Over-generalizing the property model too early |
 | Phase 4 | Analysis-value family | Highest reuse potential, but also the largest design decision | Pulling too many method-specific assumptions into one generic model |
-| Phase 5 | Deferred lookups and extensions | Only after the core review-backed gaps are addressed | Reopening Issue 6 with weak evidence or convenience-driven additions |
+| Phase 5 | Broader SEAD-wide coverage review | Only after the first cross-cutting gaps are addressed | Mistaking one project's current subset or one filtered comparison surface for the full shared-model boundary |
 
 ## GitHub-Ready Issue Drafts
 
@@ -442,7 +459,7 @@ The GitHub-ready issue bodies derived from this proposal are tracked separately 
 
 The live issues are [#447](https://github.com/humlab-sead/sead_shape_shifter/issues/447), [#448](https://github.com/humlab-sead/sead_shape_shifter/issues/448), [#449](https://github.com/humlab-sead/sead_shape_shifter/issues/449), [#450](https://github.com/humlab-sead/sead_shape_shifter/issues/450), and [#451](https://github.com/humlab-sead/sead_shape_shifter/issues/451).
 
-That file keeps the issue text in a reusable `Problem`, `Solution`, and `Files` format without expanding this proposal further.
+That file keeps the first implementation slices in a reusable `Problem`, `Solution`, and `Files` format without pretending to be the full SEAD completeness plan.
 
 ## Acceptance Criteria
 
@@ -451,8 +468,10 @@ That file keeps the issue text in a reusable `Problem`, `Solution`, and `Files` 
 Issue 5 should count as complete when all of the following are true:
 
 - this review matches the current YAML model rather than a historical expansion plan
+- this review states explicitly that the shared target model is intended as a near-complete, provider-independent SEAD superset
+- this review distinguishes the shared SEAD target model from project-specific curated subsets
 - remaining gaps are grouped into documentation gaps, target-model gaps, and schema-boundary decisions
-- the highest-value missing areas are prioritized clearly enough to drive follow-up implementation
+- the highest-value missing areas are prioritized clearly enough to drive follow-up implementation without collapsing the broader SEAD backlog to one import slice
 - the document is useful as a decision input for future model edits without requiring readers to reverse-engineer stale claims
 
 ### Issue 6
@@ -462,7 +481,7 @@ Issue 6 should count as complete when all of the following are true:
 - this document compares the current target-model-driven path with the older `SeadSchema` live-schema path explicitly
 - the comparison states that it was run against the filtered CSV snapshots rather than against an unfiltered live schema dump
 - the comparison covers source of truth, drift risk, testability, offline reproducibility, SEAD-specific output generation, and operational dependency
-- the final candidate list is constrained by the filtered review surface rather than by the broader historical backlog
+- the Issue 6 candidate list is constrained by the filtered review surface without redefining the broader completeness boundary for the SEAD target model
 - the recommendation is clear enough to guide future follow-up work without reopening the metadata boundary by accident
 
 ## References

--- a/docs/proposals/SEAD_V2_TARGET_MODEL_FOLLOWUP_ISSUES.md
+++ b/docs/proposals/SEAD_V2_TARGET_MODEL_FOLLOWUP_ISSUES.md
@@ -59,7 +59,7 @@ Files:
 
 - `docs/proposals/SEAD_V2_TARGET_MODEL_COMPLETENESS.md`
 - `docs/proposals/SEAD_V2_TARGET_MODEL_FOLLOWUP_ISSUES.md`
-- `resources/target_models/sead_standard_model.yml`
+- `resources/target_models/sead_superset_model.yml`
 - `docs/TARGET_MODEL_GUIDE.md`
 
 ## Issue 2 [feat(target_model): add sample-group context entities](https://github.com/humlab-sead/sead_shape_shifter/issues/448)
@@ -97,7 +97,7 @@ Files:
 
 - `docs/proposals/SEAD_V2_TARGET_MODEL_COMPLETENESS.md`
 - `docs/proposals/SEAD_V2_TARGET_MODEL_FOLLOWUP_ISSUES.md`
-- `resources/target_models/sead_standard_model.yml`
+- `resources/target_models/sead_superset_model.yml`
 - `docs/TARGET_MODEL_GUIDE.md`
 
 ## Issue 3 [feat(target_model): add site and feature property entities](https://github.com/humlab-sead/sead_shape_shifter/issues/449)
@@ -136,7 +136,7 @@ Files:
 
 - `docs/proposals/SEAD_V2_TARGET_MODEL_COMPLETENESS.md`
 - `docs/proposals/SEAD_V2_TARGET_MODEL_FOLLOWUP_ISSUES.md`
-- `resources/target_models/sead_standard_model.yml`
+- `resources/target_models/sead_superset_model.yml`
 - `docs/TARGET_MODEL_GUIDE.md`
 
 ## Issue 4 [feat(target_model): design generic analysis-value family](https://github.com/humlab-sead/sead_shape_shifter/issues/450)
@@ -174,7 +174,7 @@ Files:
 
 - `docs/proposals/SEAD_V2_TARGET_MODEL_COMPLETENESS.md`
 - `docs/proposals/SEAD_V2_TARGET_MODEL_FOLLOWUP_ISSUES.md`
-- `resources/target_models/sead_standard_model.yml`
+- `resources/target_models/sead_superset_model.yml`
 - `docs/TARGET_MODEL_GUIDE.md`
 
 ## Issue 5 [proposal(target_model): reassess deferred lookup and extension candidates](https://github.com/humlab-sead/sead_shape_shifter/issues/451)
@@ -212,5 +212,5 @@ Files:
 
 - `docs/proposals/SEAD_V2_TARGET_MODEL_COMPLETENESS.md`
 - `docs/proposals/SEAD_V2_TARGET_MODEL_FOLLOWUP_ISSUES.md`
-- `resources/target_models/sead_standard_model.yml`
+- `resources/target_models/sead_superset_model.yml`
 - `docs/TARGET_MODEL_GUIDE.md`

--- a/docs/proposals/SEAD_V2_TARGET_MODEL_FOLLOWUP_ISSUES.md
+++ b/docs/proposals/SEAD_V2_TARGET_MODEL_FOLLOWUP_ISSUES.md
@@ -18,18 +18,19 @@ Each issue body follows the repository's preferred `Problem`, `Solution`, and `F
 
 Current status snapshot:
 
-- Issue 1: open as [#447](https://github.com/humlab-sead/sead_shape_shifter/issues/447)
-- Issue 2: open as [#448](https://github.com/humlab-sead/sead_shape_shifter/issues/448)
-- Issue 3: open as [#449](https://github.com/humlab-sead/sead_shape_shifter/issues/449)
-- Issue 4: open as [#450](https://github.com/humlab-sead/sead_shape_shifter/issues/450)
-- Issue 5: open as [#451](https://github.com/humlab-sead/sead_shape_shifter/issues/451)
-- Issue 6: open as [#452](https://github.com/humlab-sead/sead_shape_shifter/issues/452)
+- Issue 1: open as [#447](https://github.com/humlab-sead/sead_shape_shifter/issues/447); implemented on branch in `6103f693` and `0e6a8233`
+- Issue 2: open as [#448](https://github.com/humlab-sead/sead_shape_shifter/issues/448); implemented on branch in `f934760f` and `d8a1ee64`
+- Issue 3: open as [#449](https://github.com/humlab-sead/sead_shape_shifter/issues/449); partial branch implementation in progress (`property_type`, `site_property`, `site_natgridref`)
+- Issue 4: open as [#450](https://github.com/humlab-sead/sead_shape_shifter/issues/450); implemented on branch in `f40f96cf`, `5c02cb34`, and `41adecfe`
+- Issue 5: open as [#451](https://github.com/humlab-sead/sead_shape_shifter/issues/451); not started on branch
+- Issue 6: open as [#452](https://github.com/humlab-sead/sead_shape_shifter/issues/452); implemented on branch in `68d154c0`
+- Issue 7: open as [#453](https://github.com/humlab-sead/sead_shape_shifter/issues/453); implemented on branch in `30c01497` and `5c02cb34`
 
 ## Issue 1 [feat(target_model): add sample-context entities](https://github.com/humlab-sead/sead_shape_shifter/issues/447)
 
 Status:
 
-`Open as #447`
+`Open as #447; implemented on branch`
 
 Title:
 
@@ -67,7 +68,7 @@ Files:
 
 Status:
 
-`Open as #448`
+`Open as #448; implemented on branch`
 
 Title:
 
@@ -105,7 +106,7 @@ Files:
 
 Status:
 
-`Open as #449`
+`Open as #449; partial branch implementation in progress`
 
 Title:
 
@@ -129,7 +130,11 @@ This is more than a few isolated tables. It is a cross-cutting metadata pattern 
 
 Solution:
 
-Add explicit site and feature property entities, including the shared property-type pattern needed to represent `feature_property` and `site_property` cleanly.
+Add the schema-backed property-pattern slice first: a shared `property_type` lookup plus explicit `site_property` and `site_natgridref` entities.
+
+Wire the existing `abundance_property` entity to the same shared property-type lookup so the target model no longer leaves that SEAD foreign key untyped.
+
+Keep the feature side of the issue open until the target-model representation is grounded in the SEAD schema evidence used for this proposal pass.
 
 Keep this issue limited to the property-pattern slice plus `site_natgridref`. Do not mix in sample-context entities or the generic analysis-value family.
 
@@ -144,7 +149,7 @@ Files:
 
 Status:
 
-`Open as #450`
+`Open as #450; implemented on branch`
 
 Title:
 
@@ -184,7 +189,7 @@ Files:
 
 Status:
 
-`Open as #451`
+`Open as #451; not started on branch`
 
 Title:
 
@@ -222,7 +227,7 @@ Files:
 
 Status:
 
-`Open as #452`
+`Open as #452; implemented on branch`
 
 Title:
 
@@ -257,7 +262,7 @@ Files:
 
 Status:
 
-`Open as #453`
+`Open as #453; implemented on branch`
 
 Title:
 

--- a/docs/proposals/SEAD_V2_TARGET_MODEL_FOLLOWUP_ISSUES.md
+++ b/docs/proposals/SEAD_V2_TARGET_MODEL_FOLLOWUP_ISSUES.md
@@ -1,6 +1,14 @@
 # SEAD v2 Target Model Follow-Up Issue Drafts
 
-This document turns the SEAD v2 target-model follow-up slices into GitHub-ready issue drafts.
+This document turns the first SEAD v2 target-model follow-up slices into GitHub-ready issue drafts.
+
+These issues are the first implementation tranche toward a near-complete, provider-independent SEAD target model.
+
+They are not a full inventory of all remaining SEAD target-model work.
+
+The shared target model is intended to cover almost all current SEAD tables and concepts.
+
+Individual Shape Shifter projects can then use curated subsets of that larger model.
 
 Detailed proposal home:
 
@@ -28,7 +36,9 @@ Title:
 
 Problem:
 
-The filtered Issue 6 review shows that the current target model covers the main sample core but still lacks explicit entities for several active sample-context concepts.
+The broader completeness review shows that the current target model covers the main sample core but still lacks explicit entities for several active sample-context concepts.
+
+The filtered Issue 6 review strengthens the priority of this slice, but it is not the only reason these entities belong in the shared SEAD target model.
 
 The clearest missing concepts on the filtered review surface are:
 
@@ -37,13 +47,13 @@ The clearest missing concepts on the filtered review surface are:
 - `sample_location_type`
 - `sample_note`
 
-Without these entities, the target model cannot represent the filtered sample-context tables cleanly and instead risks pushing those concepts into generic descriptions or later ad hoc extensions.
+Without these entities, the shared target model remains incomplete on an important sample-context surface and risks pushing standard SEAD concepts into generic descriptions or later ad hoc extensions.
 
 Solution:
 
 Add explicit sample-context entities for `sample_horizon`, `sample_location`, `sample_location_type`, and `sample_note`.
 
-Keep this issue limited to sample-level context. Do not mix in sample-group entities, property-pattern work, analysis-value work, or extension candidates.
+Keep this issue limited to sample-level context. Do not mix in sample-group entities, property-pattern work, analysis-value work, or broader SEAD backlog slices.
 
 Files:
 
@@ -64,7 +74,9 @@ Title:
 
 Problem:
 
-The filtered Issue 6 review also shows a distinct sample-group context surface that is still missing from the target model.
+The broader completeness review also shows a distinct sample-group context surface that is still missing from the target model.
+
+The filtered Issue 6 review strengthens the priority of this slice, but the rationale for inclusion is broader than that one comparison surface.
 
 The clearest missing concepts on that surface are:
 
@@ -73,7 +85,7 @@ The clearest missing concepts on that surface are:
 - `sample_group_note`
 - `sample_group_reference`
 
-These concepts belong with `sample_group`, but the current model does not represent them explicitly.
+These concepts belong with `sample_group`, but the current shared model does not represent them explicitly.
 
 Solution:
 
@@ -100,7 +112,9 @@ Title:
 
 Problem:
 
-The filtered Issue 6 review identifies a reusable property pattern that is present in the live-schema surface but still absent from the target model.
+The broader completeness review identifies a reusable property pattern that is present in the SEAD schema surface but still absent from the target model.
+
+The filtered Issue 6 review makes this a strong early slice, but the underlying need is broader SEAD-wide metadata coverage.
 
 The strongest current candidates are:
 
@@ -110,7 +124,7 @@ The strongest current candidates are:
 - `site_property`
 - `site_natgridref`
 
-This is more than a few isolated tables. It is a cross-cutting metadata pattern that needs an explicit target-model shape.
+This is more than a few isolated tables. It is a cross-cutting metadata pattern that needs an explicit shared-model shape.
 
 Solution:
 
@@ -137,7 +151,9 @@ Title:
 
 Problem:
 
-The filtered Issue 6 review shows that `analysis_entity` exists, but the generic analysis-value family is still missing from the target model.
+The broader completeness review shows that `analysis_entity` exists, but the generic analysis-value family is still missing from the target model.
+
+The filtered Issue 6 review makes this gap highly visible, but the need is SEAD-wide rather than specific to one provider or one current import slice.
 
 The missing surface includes:
 
@@ -146,13 +162,13 @@ The missing surface includes:
 - `analysis_identifier`
 - typed value entities such as boolean, categorical, integer, numerical, and dating-range variants
 
-This is the clearest active gap in the filtered review surface, but it also has the highest design impact because it affects how the model represents flexible typed analysis data across multiple workflows.
+This is one of the clearest active gaps, but it also has the highest design impact because it affects how the model represents flexible typed analysis data across multiple workflows and data families.
 
 Solution:
 
-Design and add a generic analysis-value family to the target model, including the core `analysis_value` entity and the smallest necessary set of typed value entities needed to represent the filtered live-schema surface cleanly.
+Design and add a generic analysis-value family to the target model, including the core `analysis_value` entity and the smallest necessary set of typed value entities needed to represent the broader SEAD analysis surface cleanly.
 
-Keep this issue focused on the analysis-value family. Do not mix in taxonomy extensions, project lookups, or unsupported Issue 6 backlog items.
+Keep this issue focused on the analysis-value family. Do not mix in taxonomy extensions, project lookups, or broader backlog slices that deserve separate design decisions.
 
 Files:
 
@@ -173,20 +189,24 @@ Title:
 
 Problem:
 
-Some concepts remain visible in the broader Issue 5 backlog, but the filtered Issue 6 evidence does not justify promoting them into immediate core-model work.
+Some concepts remain outside the first implementation slices even though they may still belong in the near-complete shared SEAD target model.
+
+The filtered Issue 6 evidence is not broad enough to settle those areas, but that does not make them out of scope for the full target-model plan.
 
 The current deferred set includes:
 
 - `project_type`, `project_stage`
 - `taxon_synonyms`, `rdb`, `taxon_measured_attributes`
+- `coordinate_system`, `dating_period`, `natural_region*`
+- `sample_colour`, `colour`, `abundance_property_type`
 
-If these concepts move forward, they should do so from explicit use cases rather than from convenience or from historical schema presence alone.
+If these concepts move forward, they should do so from explicit SEAD-wide model criteria and schema evidence rather than from one project's current subset.
 
 Solution:
 
-Run a separate decision pass for the deferred lookup and extension candidates.
+Run a separate decision pass for the broader backlog beyond the first implementation slices.
 
-Promote only the concepts that have a concrete validation or ingestion need. Leave unsupported Issue 6 backlog items such as `coordinate_system`, `dating_period`, `natural_region*`, `sample_colour`, `colour`, and `abundance_property_type` out of scope unless new evidence appears.
+Promote the concepts that belong in the near-complete shared SEAD target model, and separate them from derived tables, operational-only schema elements, and project-level subset choices.
 
 Files:
 

--- a/docs/proposals/SEAD_V2_TARGET_MODEL_FOLLOWUP_ISSUES.md
+++ b/docs/proposals/SEAD_V2_TARGET_MODEL_FOLLOWUP_ISSUES.md
@@ -20,9 +20,9 @@ Current status snapshot:
 
 - Issue 1: open as [#447](https://github.com/humlab-sead/sead_shape_shifter/issues/447); implemented on branch in `6103f693` and `0e6a8233`
 - Issue 2: open as [#448](https://github.com/humlab-sead/sead_shape_shifter/issues/448); implemented on branch in `f934760f` and `d8a1ee64`
-- Issue 3: open as [#449](https://github.com/humlab-sead/sead_shape_shifter/issues/449); implemented on branch in `4e21a10f` plus follow-up `feature_property` work
+- Issue 3: open as [#449](https://github.com/humlab-sead/sead_shape_shifter/issues/449); implemented on branch in `4e21a10f` and `fb770680`
 - Issue 4: open as [#450](https://github.com/humlab-sead/sead_shape_shifter/issues/450); implemented on branch in `f40f96cf`, `5c02cb34`, and `41adecfe`
-- Issue 5: open as [#451](https://github.com/humlab-sead/sead_shape_shifter/issues/451); not started on branch
+- Issue 5: open as [#451](https://github.com/humlab-sead/sead_shape_shifter/issues/451); implemented in working tree on branch with promoted shared lookups and explicit out-of-scope decisions
 - Issue 6: open as [#452](https://github.com/humlab-sead/sead_shape_shifter/issues/452); implemented on branch in `68d154c0`
 - Issue 7: open as [#453](https://github.com/humlab-sead/sead_shape_shifter/issues/453); implemented on branch in `30c01497` and `5c02cb34`
 
@@ -187,7 +187,7 @@ Files:
 
 Status:
 
-`Open as #451; not started on branch`
+`Open as #451; implemented in working tree on branch`
 
 Title:
 
@@ -199,18 +199,19 @@ Some concepts remain outside the first implementation slices even though they ma
 
 The filtered Issue 6 evidence is not broad enough to settle those areas, but that does not make them out of scope for the full target-model plan.
 
-The current deferred set includes:
+The current branch resolves the earlier deferred candidates in three ways:
 
-- `project_type`, `project_stage`
-- `taxon_synonyms`, `rdb`, `taxon_measured_attributes`
-- `coordinate_system`, `dating_period`, `natural_region*`
-- `sample_colour`, `colour`, `abundance_property_type`
-
-If these concepts move forward, they should do so from explicit SEAD-wide model criteria and schema evidence rather than from one project's current subset.
+- promote shared SEAD candidates: `coordinate_system`, `taxa_synonyms`, `taxa_measured_attributes`, `rdb`, `rdb_code`, `rdb_system`
+- keep `abundance_property_type` covered by the shared `property_type` model instead of adding a second abundance-only lookup family
+- reject `dating_period` and `natural_region*` as shared target-model entities because they are treated as Arbodat-specific
 
 Solution:
 
-Run a separate decision pass for the broader backlog beyond the first implementation slices.
+Run the remaining decision pass for deferred lookup and extension candidates, then either promote them into the shared superset or mark them out of scope explicitly.
+
+The current branch completes that pass for the candidates tracked in this issue by promoting `colour`, `sample_colour`, `project_type`, `project_stage`, `coordinate_system`, `taxa_synonyms`, `taxa_measured_attributes`, `rdb`, `rdb_code`, and `rdb_system` into the shared target model.
+
+It also treats `abundance_property_type` as covered by the shared `property_type` pattern rather than as a separate remaining target-model entity, and it keeps `dating_period` plus `natural_region*` out of the shared superset as Arbodat-specific concepts.
 
 Promote the concepts that belong in the near-complete shared SEAD target model, and separate them from derived tables, operational-only schema elements, and project-level subset choices.
 

--- a/docs/proposals/SEAD_V2_TARGET_MODEL_FOLLOWUP_ISSUES.md
+++ b/docs/proposals/SEAD_V2_TARGET_MODEL_FOLLOWUP_ISSUES.md
@@ -169,6 +169,8 @@ Solution:
 
 Design and add a generic analysis-value family to the target model, including the core `analysis_value` entity and the smallest necessary set of typed value entities needed to represent the broader SEAD analysis surface cleanly.
 
+Reuse the shared qualifier lookup family from [#452](https://github.com/humlab-sead/sead_shape_shifter/issues/452) for single-value qualifiers and range-bound qualifiers instead of introducing a separate analysis-only qualifier vocabulary.
+
 Keep this issue focused on the analysis-value family. Do not mix in taxonomy extensions, project lookups, or broader backlog slices that deserve separate design decisions.
 
 Files:

--- a/docs/proposals/SEAD_V2_TARGET_MODEL_FOLLOWUP_ISSUES.md
+++ b/docs/proposals/SEAD_V2_TARGET_MODEL_FOLLOWUP_ISSUES.md
@@ -22,7 +22,7 @@ Current status snapshot:
 - Issue 2: open as [#448](https://github.com/humlab-sead/sead_shape_shifter/issues/448); implemented on branch in `f934760f` and `d8a1ee64`
 - Issue 3: open as [#449](https://github.com/humlab-sead/sead_shape_shifter/issues/449); implemented on branch in `4e21a10f` and `fb770680`
 - Issue 4: open as [#450](https://github.com/humlab-sead/sead_shape_shifter/issues/450); implemented on branch in `f40f96cf`, `5c02cb34`, and `41adecfe`
-- Issue 5: open as [#451](https://github.com/humlab-sead/sead_shape_shifter/issues/451); implemented in working tree on branch with promoted shared lookups and explicit out-of-scope decisions
+- Issue 5: open as [#451](https://github.com/humlab-sead/sead_shape_shifter/issues/451); implemented on branch in `ccc53c66` with promoted shared lookups and explicit out-of-scope decisions
 - Issue 6: open as [#452](https://github.com/humlab-sead/sead_shape_shifter/issues/452); implemented on branch in `68d154c0`
 - Issue 7: open as [#453](https://github.com/humlab-sead/sead_shape_shifter/issues/453); implemented on branch in `30c01497` and `5c02cb34`
 
@@ -187,7 +187,7 @@ Files:
 
 Status:
 
-`Open as #451; implemented in working tree on branch`
+`Open as #451; implemented on branch in ccc53c66`
 
 Title:
 

--- a/docs/proposals/SEAD_V2_TARGET_MODEL_FOLLOWUP_ISSUES.md
+++ b/docs/proposals/SEAD_V2_TARGET_MODEL_FOLLOWUP_ISSUES.md
@@ -252,3 +252,39 @@ Files:
 - `docs/proposals/SEAD_V2_TARGET_MODEL_FOLLOWUP_ISSUES.md`
 - `resources/target_models/sead_superset_model.yml`
 - `docs/TARGET_MODEL_GUIDE.md`
+
+## Issue 7 [feat(target_model): add sampling context and horizon lookups](https://github.com/humlab-sead/sead_shape_shifter/issues/453)
+
+Status:
+
+`Open as #453`
+
+Title:
+
+`feat(target_model): add sampling context and horizon lookups`
+
+Problem:
+
+The current target model still treats `sample_group.sampling_context_id` and `sample_horizon.horizon_id` as untyped integers even though both columns point to named SEAD lookup tables.
+
+Schema evidence shows that `sampling_context_id` is reused beyond `tbl_sample_groups`, including sample description and sample-location-type context tables. `horizon_id` points to `tbl_horizons`, which carries its own vocabulary fields and a `method_id` reference.
+
+Leaving both columns unmodeled keeps shared SEAD vocabularies hidden inside typed integer columns and blocks clean foreign-key wiring in the sample-context slice.
+
+Solution:
+
+Add explicit target-model lookup entities for the shared context family:
+
+- `sample_group_sampling_context` for `tbl_sample_group_sampling_contexts`
+- `horizon` for `tbl_horizons`
+
+Update the direct consumer entities to reference those lookups explicitly, starting with `sample_group` and `sample_horizon`.
+
+Keep this issue focused on the shared lookup entities and the direct foreign keys already present in the current model. Do not mix in broader sample-description extension tables unless they are needed to complete the same lookup family cleanly.
+
+Files:
+
+- `docs/proposals/SEAD_V2_TARGET_MODEL_COMPLETENESS.md`
+- `docs/proposals/SEAD_V2_TARGET_MODEL_FOLLOWUP_ISSUES.md`
+- `resources/target_models/sead_superset_model.yml`
+- `docs/TARGET_MODEL_GUIDE.md`

--- a/docs/proposals/SEAD_V2_TARGET_MODEL_FOLLOWUP_ISSUES.md
+++ b/docs/proposals/SEAD_V2_TARGET_MODEL_FOLLOWUP_ISSUES.md
@@ -23,6 +23,7 @@ Current status snapshot:
 - Issue 3: open as [#449](https://github.com/humlab-sead/sead_shape_shifter/issues/449)
 - Issue 4: open as [#450](https://github.com/humlab-sead/sead_shape_shifter/issues/450)
 - Issue 5: open as [#451](https://github.com/humlab-sead/sead_shape_shifter/issues/451)
+- Issue 6: open as [#452](https://github.com/humlab-sead/sead_shape_shifter/issues/452)
 
 ## Issue 1 [feat(target_model): add sample-context entities](https://github.com/humlab-sead/sead_shape_shifter/issues/447)
 
@@ -207,6 +208,41 @@ Solution:
 Run a separate decision pass for the broader backlog beyond the first implementation slices.
 
 Promote the concepts that belong in the near-complete shared SEAD target model, and separate them from derived tables, operational-only schema elements, and project-level subset choices.
+
+Files:
+
+- `docs/proposals/SEAD_V2_TARGET_MODEL_COMPLETENESS.md`
+- `docs/proposals/SEAD_V2_TARGET_MODEL_FOLLOWUP_ISSUES.md`
+- `resources/target_models/sead_superset_model.yml`
+- `docs/TARGET_MODEL_GUIDE.md`
+
+## Issue 6 [feat(target_model): add value qualifier lookup entities](https://github.com/humlab-sead/sead_shape_shifter/issues/452)
+
+Status:
+
+`Open as #452`
+
+Title:
+
+`feat(target_model): add value qualifier lookup entities`
+
+Problem:
+
+The recent sample and sample-group context work exposed a missing shared lookup family rather than a local gap in one entity.
+
+Both `sample_dimension` and `sample_group_dimension` use `qualifier_id`, but the target model still treats that field as an untyped integer because there is no explicit target-model entity for `tbl_value_qualifiers`.
+
+The same lookup family also appears in multiple analysis value and range tables through `tbl_value_qualifier_symbols`.
+
+Without explicit qualifier lookup entities, projects cannot model these references cleanly, and follow-up slices keep accumulating deferred foreign keys that all point to the same shared SEAD vocabulary.
+
+Solution:
+
+Add explicit shared lookup entities for the SEAD value qualifier family, starting with `value_qualifier` and `value_qualifier_symbol`.
+
+Update the target model so sample dimension entities can reference that lookup family explicitly, and document how later analysis-value work should reuse the same qualifier entities instead of inventing a parallel representation.
+
+Keep this issue focused on the shared lookup family and the direct references already present in sample dimension entities. Do not mix in the broader design of the generic analysis-value family.
 
 Files:
 

--- a/docs/proposals/SEAD_V2_TARGET_MODEL_FOLLOWUP_ISSUES.md
+++ b/docs/proposals/SEAD_V2_TARGET_MODEL_FOLLOWUP_ISSUES.md
@@ -20,7 +20,7 @@ Current status snapshot:
 
 - Issue 1: open as [#447](https://github.com/humlab-sead/sead_shape_shifter/issues/447); implemented on branch in `6103f693` and `0e6a8233`
 - Issue 2: open as [#448](https://github.com/humlab-sead/sead_shape_shifter/issues/448); implemented on branch in `f934760f` and `d8a1ee64`
-- Issue 3: open as [#449](https://github.com/humlab-sead/sead_shape_shifter/issues/449); partial branch implementation in progress (`property_type`, `site_property`, `site_natgridref`)
+- Issue 3: open as [#449](https://github.com/humlab-sead/sead_shape_shifter/issues/449); implemented on branch in `4e21a10f` plus follow-up `feature_property` work
 - Issue 4: open as [#450](https://github.com/humlab-sead/sead_shape_shifter/issues/450); implemented on branch in `f40f96cf`, `5c02cb34`, and `41adecfe`
 - Issue 5: open as [#451](https://github.com/humlab-sead/sead_shape_shifter/issues/451); not started on branch
 - Issue 6: open as [#452](https://github.com/humlab-sead/sead_shape_shifter/issues/452); implemented on branch in `68d154c0`
@@ -106,7 +106,7 @@ Files:
 
 Status:
 
-`Open as #449; partial branch implementation in progress`
+`Open as #449; implemented on branch`
 
 Title:
 
@@ -130,11 +130,9 @@ This is more than a few isolated tables. It is a cross-cutting metadata pattern 
 
 Solution:
 
-Add the schema-backed property-pattern slice first: a shared `property_type` lookup plus explicit `site_property` and `site_natgridref` entities.
+Add the schema-backed property-pattern slice using the shared `property_type` table plus explicit `site_property`, `feature_property`, and `site_natgridref` entities.
 
 Wire the existing `abundance_property` entity to the same shared property-type lookup so the target model no longer leaves that SEAD foreign key untyped.
-
-Keep the feature side of the issue open until the target-model representation is grounded in the SEAD schema evidence used for this proposal pass.
 
 Keep this issue limited to the property-pattern slice plus `site_natgridref`. Do not mix in sample-context entities or the generic analysis-value family.
 

--- a/docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md
+++ b/docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md
@@ -54,7 +54,7 @@ See [Target-Model-Aware Data Conformance](#target-model-aware-data-conformance) 
 - [ ] Remote target model references (SSRF-safe, with caching)
 - [ ] Curated target model registry (bundled YAML short-name resolution)
 
-### SEAD spec coverage (`resources/target_models/sead_standard_model.yml`)
+### SEAD spec coverage (`resources/target_models/sead_superset_model.yml`)
 - [x] Abundance chain — `abundance`, `abundance_element`, `abundance_element_group`, `abundance_modification`, `modification_type`, `abundance_property`
 - [x] Dating — `relative_dating`, `relative_ages`, `geochronology` (abs/radiocarbon), `dating_lab`
 - [x] Method/contacts — `method_group`, `citation` (`tbl_biblio`), `contact`, `contact_type`, `dataset_contact`
@@ -283,7 +283,7 @@ The project-level YAML view currently shows only the `shapeshifter.yml` file. Wh
 
 **Constraints:**
 - Raw YAML only — no structured form or entity-level UI.
-- Tab visible only when the project has a `target_model:` reference that resolves to a **project-local file** (i.e. the `@include:` path lives inside the project's own directory). Shared/global spec files (e.g. `resources/target_models/sead_standard_model.yml`) are read-only in this view.
+- Tab visible only when the project has a `target_model:` reference that resolves to a **project-local file** (i.e. the `@include:` path lives inside the project's own directory). Shared/global spec files (e.g. `resources/target_models/sead_superset_model.yml`) are read-only in this view.
 - API passes the YAML file content as raw text; the server validates syntax but **never re-serialises** it, so comments and formatting survive the round-trip.
 - Save writes directly to the referenced target model YAML file.
 - Changing the file triggers a re-run of conformance validation (same as editing the project YAML).
@@ -584,7 +584,7 @@ These test areas were identified in the implementation sketch but not yet covere
 ### `@include:` Resolution (Backend Boundary)
 
 - Inline `target_model: {...}` dict passes through mapper unchanged
-- `target_model: "@include: resources/target_models/sead_standard_model.yml"` resolves to dict at mapper boundary
+- `target_model: "@include: resources/target_models/sead_superset_model.yml"` resolves to dict at mapper boundary
 - Missing include file produces a clear error, not a cryptic KeyError
 - Relative path resolution from project file location
 
@@ -731,7 +731,7 @@ Generate human-readable documentation for target models in HTML, Markdown, or Ex
 
 ## SEAD Coverage Backlog
 
-Lower-frequency SEAD tables not yet represented in `resources/target_models/sead_standard_model.yml`:
+Lower-frequency SEAD tables not yet represented in `resources/target_models/sead_superset_model.yml`:
 
 - Abundance chain entities (`abundance`, `abundance_element`, `abundance_modification`)
 - Dating entities (`relative_dating`, `relative_age`, `radiocarbon_dating`)
@@ -741,7 +741,7 @@ Lower-frequency SEAD tables not yet represented in `resources/target_models/sead
 
 **Note:** These are SEAD spec coverage gaps, not framework gaps. The conformance engine supports them — the spec YAML just has not been written yet.
 
-**Approach:** Add entity blocks to `sead_standard_model.yml` incrementally as real projects exercise those entity types. Prefer driven-by-need over speculative coverage.
+**Approach:** Add entity blocks to `sead_superset_model.yml` incrementally as real projects exercise those entity types. Prefer driven-by-need over speculative coverage.
 
 ---
 

--- a/docs/testing/TARGET_MODEL_CONFORMANCE_MANUAL_TEST_CHECKLIST.md
+++ b/docs/testing/TARGET_MODEL_CONFORMANCE_MANUAL_TEST_CHECKLIST.md
@@ -35,7 +35,7 @@ This guide verifies:
 
 This guide does **not** attempt to manually verify:
 
-- large-scale target-model completeness across every SEAD entity in `sead_standard_model.yml`
+- large-scale target-model completeness across every SEAD entity in `sead_superset_model.yml`
 - deferred semantic-role heuristics and branch-aware conformance backlog
 - automated unit-test coverage for `TargetModelSpecValidator`
 - performance, browser compatibility, or accessibility
@@ -147,7 +147,7 @@ Use the existing file [target_models/examples/sead_missing_sample_group.yml](../
 Before testing, add this field to the `metadata` block:
 
 ```yaml
-target_model: "@include: resources/target_models/sead_standard_model.yml"
+target_model: "@include: resources/target_models/sead_superset_model.yml"
 ```
 
 Why this fixture matters:
@@ -162,7 +162,7 @@ Use the existing file [target_models/examples/sead_arbodat_core.yml](../../targe
 Before testing, add this field to the `metadata` block:
 
 ```yaml
-target_model: "@include: resources/target_models/sead_standard_model.yml"
+target_model: "@include: resources/target_models/sead_superset_model.yml"
 ```
 
 Why this fixture matters:
@@ -449,7 +449,7 @@ This section confirms both a missing direct target relationship and the loss of 
 ### Steps
 
 1. Open Fixture B: [target_models/examples/sead_missing_sample_group.yml](../../target_models/examples/sead_missing_sample_group.yml).
-2. Ensure the metadata block includes `target_model: "@include: resources/target_models/sead_standard_model.yml"`.
+2. Ensure the metadata block includes `target_model: "@include: resources/target_models/sead_superset_model.yml"`.
 3. Save the project under a disposable test name if you do not want to edit the example directly.
 4. Run **Check Conformance**.
 5. Review the **Conformance** results by code and by entity.
@@ -475,7 +475,7 @@ This fixture is the main manual regression check for the proposal's core rule fa
 ### Steps
 
 1. Open Fixture C: [target_models/examples/sead_arbodat_core.yml](../../target_models/examples/sead_arbodat_core.yml).
-2. Ensure the metadata block includes `target_model: "@include: resources/target_models/sead_standard_model.yml"`.
+2. Ensure the metadata block includes `target_model: "@include: resources/target_models/sead_superset_model.yml"`.
 3. Save the project under a disposable name if needed.
 4. Run **Check Conformance**.
 5. Compare the actual issues to the expected narrow set below.
@@ -539,7 +539,7 @@ Run the same project through the CLI conformance entry point:
 
 ```bash
 python -m src.target_model.conformance \
-  --spec resources/target_models/sead_standard_model.yml \
+  --spec resources/target_models/sead_superset_model.yml \
   --project target_models/examples/sead_missing_sample_group.yml
 ```
 

--- a/frontend/src/schemas/projectSchema.json
+++ b/frontend/src/schemas/projectSchema.json
@@ -128,7 +128,8 @@
         }
       },
       "required": [
-        "name"
+        "name",
+        "entity_count"
       ],
       "title": "ProjectMetadata",
       "type": "object"

--- a/frontend/src/schemas/targetModelSchema.json
+++ b/frontend/src/schemas/targetModelSchema.json
@@ -1,6 +1,7 @@
 {
   "$defs": {
     "ColumnSpec": {
+      "additionalProperties": false,
       "properties": {
         "required": {
           "default": false,
@@ -48,6 +49,7 @@
       "type": "object"
     },
     "EntitySpec": {
+      "additionalProperties": false,
       "properties": {
         "role": {
           "anyOf": [
@@ -201,6 +203,7 @@
       "type": "object"
     },
     "ForeignKeySpec": {
+      "additionalProperties": false,
       "properties": {
         "entity": {
           "title": "Entity",
@@ -231,6 +234,7 @@
       "type": "object"
     },
     "GlobalConstraint": {
+      "additionalProperties": false,
       "properties": {
         "type": {
           "title": "Type",
@@ -244,6 +248,7 @@
       "type": "object"
     },
     "ModelMetadata": {
+      "additionalProperties": false,
       "properties": {
         "name": {
           "title": "Name",
@@ -274,6 +279,7 @@
       "type": "object"
     },
     "NamingConventions": {
+      "additionalProperties": false,
       "properties": {
         "public_id_suffix": {
           "anyOf": [
@@ -292,6 +298,7 @@
       "type": "object"
     }
   },
+  "additionalProperties": false,
   "properties": {
     "model": {
       "$ref": "#/$defs/ModelMetadata"

--- a/resources/target_models/sead_superset_model.yml
+++ b/resources/target_models/sead_superset_model.yml
@@ -944,6 +944,215 @@ entities:
       - entity: dataset
         required: true
 
+  analysis_value:
+    role: fact
+    required: false
+    description: Core analysis value record attached to an analysis entity.
+    aggregate_parent: analysis_entity
+    domains: [analysis]
+    target_table: tbl_analysis_values
+    public_id: analysis_value_id
+    identity_columns: [analysis_entity_id, value_class_id, analysis_value]
+    columns:
+      analysis_entity_id:
+        required: true
+        type: integer
+        nullable: false
+      value_class_id:
+        type: integer
+        nullable: true
+      analysis_value:
+        type: string
+        nullable: true
+      boolean_value:
+        type: boolean
+        nullable: true
+      is_boolean:
+        type: boolean
+        nullable: true
+      is_uncertain:
+        type: boolean
+        nullable: true
+      is_undefined:
+        type: boolean
+        nullable: true
+      is_not_analyzed:
+        type: boolean
+        nullable: true
+      is_indeterminable:
+        type: boolean
+        nullable: true
+      is_anomaly:
+        type: boolean
+        nullable: true
+    foreign_keys:
+      - entity: analysis_entity
+        required: true
+
+  analysis_note:
+    role: fact
+    required: false
+    description: Free-text note attached to an analysis value.
+    aggregate_parent: analysis_value
+    domains: [analysis]
+    target_table: tbl_analysis_notes
+    public_id: analysis_note_id
+    identity_columns: [analysis_value_id, value]
+    columns:
+      analysis_value_id:
+        required: true
+        type: integer
+        nullable: false
+      value:
+        required: true
+        type: string
+        nullable: false
+    unique_sets:
+      - [analysis_value_id, value]
+    foreign_keys:
+      - entity: analysis_value
+        required: true
+
+  analysis_identifier:
+    role: fact
+    required: false
+    description: Identifier string attached to an analysis value.
+    aggregate_parent: analysis_value
+    domains: [analysis]
+    target_table: tbl_analysis_identifiers
+    public_id: analysis_identifier_id
+    identity_columns: [analysis_value_id, value]
+    columns:
+      analysis_value_id:
+        required: true
+        type: integer
+        nullable: false
+      value:
+        required: true
+        type: string
+        nullable: false
+    unique_sets:
+      - [analysis_value_id, value]
+    foreign_keys:
+      - entity: analysis_value
+        required: true
+
+  analysis_integer_value:
+    role: fact
+    required: false
+    description: Integer-valued analysis result with an optional qualifier symbol.
+    aggregate_parent: analysis_value
+    domains: [analysis]
+    target_table: tbl_analysis_integer_values
+    public_id: analysis_integer_value_id
+    identity_columns: [analysis_value_id, qualifier, value]
+    columns:
+      analysis_value_id:
+        required: true
+        type: integer
+        nullable: false
+      qualifier:
+        type: string
+        nullable: true
+      value:
+        required: true
+        type: integer
+        nullable: false
+      is_variant:
+        type: boolean
+        nullable: true
+    foreign_keys:
+      - entity: analysis_value
+        required: true
+      - entity: value_qualifier_symbol
+        required: false
+
+  analysis_numerical_value:
+    role: fact
+    required: false
+    description: Numerical analysis result with an optional qualifier symbol.
+    aggregate_parent: analysis_value
+    domains: [analysis]
+    target_table: tbl_analysis_numerical_values
+    public_id: analysis_numerical_value_id
+    identity_columns: [analysis_value_id, qualifier, value]
+    columns:
+      analysis_value_id:
+        required: true
+        type: integer
+        nullable: false
+      qualifier:
+        type: string
+        nullable: true
+      value:
+        required: true
+        type: decimal
+        nullable: false
+      is_variant:
+        type: boolean
+        nullable: true
+    foreign_keys:
+      - entity: analysis_value
+        required: true
+      - entity: value_qualifier_symbol
+        required: false
+
+  analysis_dating_range:
+    role: fact
+    required: false
+    description: Qualified dating range attached to an analysis value.
+    aggregate_parent: analysis_value
+    domains: [analysis, dating]
+    target_table: tbl_analysis_dating_ranges
+    public_id: analysis_dating_range_id
+    identity_columns: [analysis_value_id, low_value, high_value, low_qualifier, high_qualifier]
+    columns:
+      analysis_value_id:
+        required: true
+        type: integer
+        nullable: false
+      low_value:
+        required: true
+        type: integer
+        nullable: false
+      high_value:
+        required: true
+        type: integer
+        nullable: false
+      low_is_uncertain:
+        type: boolean
+        nullable: true
+      high_is_uncertain:
+        type: boolean
+        nullable: true
+      low_qualifier:
+        type: string
+        nullable: true
+      high_qualifier:
+        type: string
+        nullable: true
+      age_type_id:
+        type: integer
+        nullable: true
+      season_id:
+        type: integer
+        nullable: true
+      dating_uncertainty_id:
+        type: integer
+        nullable: true
+      is_variant:
+        type: boolean
+        nullable: true
+    foreign_keys:
+      - entity: analysis_value
+        required: true
+      - entity: value_qualifier_symbol
+        required: false
+      - entity: age_type
+        required: false
+      - entity: dating_uncertainty
+        required: false
+
   abundance:
     role: fact
     required: false

--- a/resources/target_models/sead_superset_model.yml
+++ b/resources/target_models/sead_superset_model.yml
@@ -482,6 +482,106 @@ entities:
       - entity: method
         required: true
 
+  sample_location_type:
+    role: classifier
+    required: false
+    description: Controlled vocabulary for within-sample location descriptions.
+    domains: [sample-metadata, spatial]
+    target_table: tbl_sample_location_types
+    public_id: sample_location_type_id
+    identity_columns: [location_type]
+    columns:
+      location_type:
+        required: true
+        type: string
+        nullable: false
+      location_type_description:
+        type: string
+        nullable: true
+    unique_sets:
+      - [location_type]
+
+  sample_location:
+    role: fact
+    required: false
+    description: Typed within-sample location note attached to a physical sample.
+    aggregate_parent: sample
+    domains: [sample-metadata, spatial]
+    target_table: tbl_sample_locations
+    public_id: sample_location_id
+    identity_columns: [physical_sample_id, sample_location_type_id, location]
+    columns:
+      physical_sample_id:
+        required: true
+        type: integer
+        nullable: false
+      sample_location_type_id:
+        required: true
+        type: integer
+        nullable: false
+      location:
+        required: true
+        type: string
+        nullable: false
+    unique_sets:
+      - [physical_sample_id, sample_location_type_id, location]
+    foreign_keys:
+      - entity: sample
+        required: true
+      - entity: sample_location_type
+        required: true
+
+  sample_note:
+    role: fact
+    required: false
+    description: Free-text note attached to a physical sample.
+    aggregate_parent: sample
+    domains: [sample-metadata]
+    target_table: tbl_sample_notes
+    public_id: sample_note_id
+    identity_columns: [physical_sample_id, note_type, note]
+    columns:
+      physical_sample_id:
+        required: true
+        type: integer
+        nullable: false
+      note_type:
+        type: string
+        nullable: true
+      note:
+        required: true
+        type: string
+        nullable: false
+    unique_sets:
+      - [physical_sample_id, note_type, note]
+    foreign_keys:
+      - entity: sample
+        required: true
+
+  sample_horizon:
+    role: fact
+    required: false
+    description: Horizon assignment attached to a physical sample.
+    aggregate_parent: sample
+    domains: [sample-metadata]
+    target_table: tbl_sample_horizons
+    public_id: sample_horizon_id
+    identity_columns: [physical_sample_id, horizon_id]
+    columns:
+      physical_sample_id:
+        required: true
+        type: integer
+        nullable: false
+      horizon_id:
+        required: true
+        type: integer
+        nullable: false
+    unique_sets:
+      - [physical_sample_id, horizon_id]
+    foreign_keys:
+      - entity: sample
+        required: true
+
   method:
     role: classifier
     required: true

--- a/resources/target_models/sead_superset_model.yml
+++ b/resources/target_models/sead_superset_model.yml
@@ -202,6 +202,118 @@ entities:
       - entity: method
         required: true
 
+  sample_group_coordinate:
+    role: fact
+    required: false
+    description: Coordinate or position measurement attached to a sample group.
+    aggregate_parent: sample_group
+    domains: [spatial, sample-metadata]
+    target_table: tbl_sample_group_coordinates
+    public_id: sample_group_position_id
+    identity_columns: [sample_group_id, coordinate_method_dimension_id]
+    columns:
+      sample_group_id:
+        required: true
+        type: integer
+        nullable: false
+      coordinate_method_dimension_id:
+        required: true
+        type: integer
+        nullable: false
+      sample_group_position:
+        required: true
+        type: decimal
+        nullable: false
+      position_accuracy:
+        type: string
+        nullable: true
+    foreign_keys:
+      - entity: sample_group
+        required: true
+      - entity: coordinate_method_dimension
+        required: true
+
+  sample_group_dimension:
+    role: fact
+    required: false
+    description: Physical dimension measurement attached to a sample group.
+    aggregate_parent: sample_group
+    domains: [sample-metadata, physical-properties]
+    target_table: tbl_sample_group_dimensions
+    public_id: sample_group_dimension_id
+    identity_columns: [sample_group_id, dimension_id]
+    columns:
+      sample_group_id:
+        required: true
+        type: integer
+        nullable: false
+      dimension_id:
+        required: true
+        type: integer
+        nullable: false
+      dimension_value:
+        required: true
+        type: decimal
+        nullable: false
+      qualifier_id:
+        type: integer
+        nullable: true
+    foreign_keys:
+      - entity: sample_group
+        required: true
+      - entity: dimension
+        required: true
+
+  sample_group_note:
+    role: fact
+    required: false
+    description: Free-text note attached to a sample group.
+    aggregate_parent: sample_group
+    domains: [sample-metadata]
+    target_table: tbl_sample_group_notes
+    public_id: sample_group_note_id
+    identity_columns: [sample_group_id, note]
+    columns:
+      sample_group_id:
+        required: true
+        type: integer
+        nullable: false
+      note:
+        required: true
+        type: string
+        nullable: false
+    unique_sets:
+      - [sample_group_id, note]
+    foreign_keys:
+      - entity: sample_group
+        required: true
+
+  sample_group_reference:
+    role: fact
+    required: false
+    description: Bibliographic reference attached to a sample group.
+    aggregate_parent: sample_group
+    domains: [sample-metadata, provenance, bibliography]
+    target_table: tbl_sample_group_references
+    public_id: sample_group_reference_id
+    identity_columns: [sample_group_id, biblio_id]
+    columns:
+      sample_group_id:
+        required: true
+        type: integer
+        nullable: false
+      biblio_id:
+        required: true
+        type: integer
+        nullable: false
+    unique_sets:
+      - [sample_group_id, biblio_id]
+    foreign_keys:
+      - entity: sample_group
+        required: true
+      - entity: citation
+        required: true
+
   sample:
     role: fact
     required: true

--- a/resources/target_models/sead_superset_model.yml
+++ b/resources/target_models/sead_superset_model.yml
@@ -201,6 +201,30 @@ entities:
         required: true
       - entity: method
         required: true
+      - entity: sample_group_sampling_context
+        required: false
+
+  sample_group_sampling_context:
+    role: classifier
+    required: false
+    description: Controlled vocabulary for sampling contexts attached to sample groups and related sample metadata tables.
+    domains: [core, sample-metadata]
+    target_table: tbl_sample_group_sampling_contexts
+    public_id: sampling_context_id
+    identity_columns: [sampling_context]
+    columns:
+      sampling_context:
+        required: true
+        type: string
+        nullable: false
+      description:
+        type: string
+        nullable: true
+      sort_order:
+        type: integer
+        nullable: true
+    unique_sets:
+      - [sampling_context]
 
   sample_group_coordinate:
     role: fact
@@ -742,6 +766,34 @@ entities:
     foreign_keys:
       - entity: sample
         required: true
+      - entity: horizon
+        required: true
+
+  horizon:
+    role: classifier
+    required: false
+    description: Controlled horizon vocabulary referenced by sample horizon assignments.
+    domains: [sample-metadata]
+    target_table: tbl_horizons
+    public_id: horizon_id
+    identity_columns: [horizon_name, method_id]
+    columns:
+      horizon_name:
+        required: true
+        type: string
+        nullable: false
+      description:
+        type: string
+        nullable: true
+      method_id:
+        required: true
+        type: integer
+        nullable: false
+    unique_sets:
+      - [horizon_name, method_id]
+    foreign_keys:
+      - entity: method
+        required: true
 
   method:
     role: classifier
@@ -1037,6 +1089,31 @@ entities:
       - entity: analysis_value
         required: true
 
+  analysis_boolean_value:
+    role: fact
+    required: false
+    description: Boolean analysis result recorded as a typed child row of an analysis value.
+    aggregate_parent: analysis_value
+    domains: [analysis]
+    target_table: tbl_analysis_boolean_values
+    public_id: analysis_boolean_value_id
+    identity_columns: [analysis_value_id, qualifier, value]
+    columns:
+      analysis_value_id:
+        required: true
+        type: integer
+        nullable: false
+      qualifier:
+        type: string
+        nullable: true
+      value:
+        required: true
+        type: boolean
+        nullable: false
+    foreign_keys:
+      - entity: analysis_value
+        required: true
+
   analysis_integer_value:
     role: fact
     required: false
@@ -1058,6 +1135,49 @@ entities:
         required: true
         type: integer
         nullable: false
+      is_variant:
+        type: boolean
+        nullable: true
+    foreign_keys:
+      - entity: analysis_value
+        required: true
+      - entity: value_qualifier_symbol
+        required: false
+
+  analysis_integer_range:
+    role: fact
+    required: false
+    description: Qualified integer range attached to an analysis value.
+    aggregate_parent: analysis_value
+    domains: [analysis]
+    target_table: tbl_analysis_integer_ranges
+    public_id: analysis_integer_range_id
+    identity_columns: [analysis_value_id, low_value, high_value, low_qualifier, high_qualifier]
+    columns:
+      analysis_value_id:
+        required: true
+        type: integer
+        nullable: false
+      low_value:
+        required: true
+        type: integer
+        nullable: false
+      high_value:
+        required: true
+        type: integer
+        nullable: false
+      low_is_uncertain:
+        type: boolean
+        nullable: true
+      high_is_uncertain:
+        type: boolean
+        nullable: true
+      low_qualifier:
+        type: string
+        nullable: true
+      high_qualifier:
+        type: string
+        nullable: true
       is_variant:
         type: boolean
         nullable: true
@@ -1096,6 +1216,62 @@ entities:
         required: true
       - entity: value_qualifier_symbol
         required: false
+
+  analysis_taxon_count:
+    role: fact
+    required: false
+    description: Taxon-specific count attached to an analysis value.
+    aggregate_parent: analysis_value
+    domains: [analysis, taxonomy]
+    target_table: tbl_analysis_taxon_counts
+    public_id: analysis_taxon_count_id
+    identity_columns: [analysis_value_id, taxon_id]
+    columns:
+      analysis_value_id:
+        required: true
+        type: integer
+        nullable: false
+      taxon_id:
+        required: true
+        type: integer
+        nullable: false
+      value:
+        required: true
+        type: decimal
+        nullable: false
+    foreign_keys:
+      - entity: analysis_value
+        required: true
+      - entity: taxa_tree_master
+        required: true
+
+  analysis_value_dimension:
+    role: fact
+    required: false
+    description: Dimension measurement attached directly to an analysis value.
+    aggregate_parent: analysis_value
+    domains: [analysis]
+    target_table: tbl_analysis_value_dimensions
+    public_id: analysis_value_dimension_id
+    identity_columns: [analysis_value_id, dimension_id]
+    columns:
+      analysis_value_id:
+        required: true
+        type: integer
+        nullable: false
+      dimension_id:
+        required: true
+        type: integer
+        nullable: false
+      value:
+        required: true
+        type: decimal
+        nullable: false
+    foreign_keys:
+      - entity: analysis_value
+        required: true
+      - entity: dimension
+        required: true
 
   analysis_dating_range:
     role: fact

--- a/resources/target_models/sead_superset_model.yml
+++ b/resources/target_models/sead_superset_model.yml
@@ -263,6 +263,8 @@ entities:
         required: true
       - entity: dimension
         required: true
+      - entity: value_qualifier
+        required: false
 
   sample_group_note:
     role: fact
@@ -530,6 +532,48 @@ entities:
     unique_sets:
       - [alt_ref_type]
 
+  value_qualifier:
+    role: classifier
+    required: false
+    description: Base qualifier vocabulary for qualified values such as greater-than or less-than.
+    domains: [sample-metadata, analysis]
+    target_table: tbl_value_qualifiers
+    public_id: qualifier_id
+    identity_columns: [symbol]
+    columns:
+      symbol:
+        required: true
+        type: string
+        nullable: false
+      description:
+        type: string
+        nullable: true
+    unique_sets:
+      - [symbol]
+
+  value_qualifier_symbol:
+    role: classifier
+    required: false
+    description: Alternate symbol mapped to a base value qualifier.
+    domains: [sample-metadata, analysis]
+    target_table: tbl_value_qualifier_symbols
+    public_id: qualifier_symbol_id
+    identity_columns: [symbol]
+    columns:
+      symbol:
+        required: true
+        type: string
+        nullable: false
+      cardinal_qualifier_id:
+        required: true
+        type: integer
+        nullable: false
+    unique_sets:
+      - [symbol]
+    foreign_keys:
+      - entity: value_qualifier
+        required: true
+
   sample_alt_ref:
     role: fact
     required: false
@@ -586,6 +630,9 @@ entities:
         required: true
         type: decimal
         nullable: false
+      qualifier_id:
+        type: integer
+        nullable: true
     foreign_keys:
       - entity: sample
         required: true
@@ -593,6 +640,8 @@ entities:
         required: true
       - entity: method
         required: true
+      - entity: value_qualifier
+        required: false
 
   sample_location_type:
     role: classifier

--- a/resources/target_models/sead_superset_model.yml
+++ b/resources/target_models/sead_superset_model.yml
@@ -423,6 +423,32 @@ entities:
       - entity: sample_description_type
         required: true
 
+  sample_colour:
+    role: fact
+    required: false
+    description: Colour observation attached to a physical sample.
+    aggregate_parent: sample
+    domains: [sample-metadata]
+    target_table: tbl_sample_colours
+    public_id: sample_colour_id
+    identity_columns: [physical_sample_id, colour_id]
+    columns:
+      physical_sample_id:
+        required: true
+        type: integer
+        nullable: false
+      colour_id:
+        required: true
+        type: integer
+        nullable: false
+    unique_sets:
+      - [physical_sample_id, colour_id]
+    foreign_keys:
+      - entity: sample
+        required: true
+      - entity: colour
+        required: true
+
   sample_type:
     role: classifier
     required: true
@@ -504,6 +530,25 @@ entities:
       - entity: dimension
         required: true
 
+  coordinate_system:
+    role: classifier
+    required: false
+    description: Controlled vocabulary for coordinate reference systems used by SEAD spatial data.
+    domains: [spatial]
+    target_table: tbl_coordinate_systems
+    public_id: coordinate_system_id
+    identity_columns: [coordinate_system]
+    columns:
+      coordinate_system:
+        required: true
+        type: string
+        nullable: true
+      description:
+        type: string
+        nullable: true
+    unique_sets:
+      - [coordinate_system]
+
   sample_coordinate:
     role: fact
     required: false
@@ -555,6 +600,32 @@ entities:
         nullable: true
     unique_sets:
       - [alt_ref_type]
+
+  colour:
+    role: classifier
+    required: false
+    description: Controlled colour vocabulary used by sample-colour observations.
+    domains: [sample-metadata]
+    target_table: tbl_colours
+    public_id: colour_id
+    identity_columns: [method_id, colour_name]
+    columns:
+      method_id:
+        required: true
+        type: integer
+        nullable: false
+      colour_name:
+        required: true
+        type: string
+        nullable: false
+      rgb:
+        type: integer
+        nullable: true
+    unique_sets:
+      - [method_id, colour_name]
+    foreign_keys:
+      - entity: method
+        required: true
 
   value_qualifier:
     role: classifier
@@ -1035,6 +1106,49 @@ entities:
         nullable: true
     unique_sets:
       - [project_abbrev_name]
+    foreign_keys:
+      - entity: project_type
+        required: false
+      - entity: project_stage
+        required: false
+
+  project_type:
+    role: classifier
+    required: false
+    description: Controlled vocabulary for project classification.
+    domains: [core, provenance]
+    target_table: tbl_project_types
+    public_id: project_type_id
+    identity_columns: [project_type_name]
+    columns:
+      project_type_name:
+        required: true
+        type: string
+        nullable: true
+      description:
+        type: string
+        nullable: true
+    unique_sets:
+      - [project_type_name]
+
+  project_stage:
+    role: classifier
+    required: false
+    description: Controlled vocabulary for project stage or lifecycle state.
+    domains: [core, provenance]
+    target_table: tbl_project_stages
+    public_id: project_stage_id
+    identity_columns: [stage_name]
+    columns:
+      stage_name:
+        required: true
+        type: string
+        nullable: true
+      description:
+        type: string
+        nullable: true
+    unique_sets:
+      - [stage_name]
 
   citation:
     role: lookup
@@ -1763,6 +1877,173 @@ entities:
         type: integer
         nullable: true
     foreign_keys:
+      - entity: taxa_tree_master
+        required: true
+
+  taxa_synonyms:
+    role: lookup
+    required: false
+    description: Alternate taxon names recorded for SEAD taxonomy entries.
+    aggregate_parent: taxa_tree_master
+    domains: [taxonomy]
+    target_table: tbl_taxa_synonyms
+    public_id: synonym_id
+    identity_columns: [taxon_id, biblio_id, synonym]
+    columns:
+      biblio_id:
+        required: true
+        type: integer
+        nullable: false
+      family_id:
+        type: integer
+        nullable: true
+      genus_id:
+        type: integer
+        nullable: true
+      notes:
+        type: string
+        nullable: true
+      taxon_id:
+        type: integer
+        nullable: true
+      author_id:
+        type: integer
+        nullable: true
+      synonym:
+        type: string
+        nullable: true
+      reference_type:
+        type: string
+        nullable: true
+      synonym_uuid:
+        required: true
+        type: string
+        nullable: false
+    foreign_keys:
+      - entity: citation
+        required: true
+      - entity: taxa_tree_master
+        required: false
+
+  taxa_measured_attributes:
+    role: fact
+    required: false
+    description: Measured attribute values attached to a taxon record.
+    aggregate_parent: taxa_tree_master
+    domains: [taxonomy]
+    target_table: tbl_taxa_measured_attributes
+    public_id: measured_attribute_id
+    identity_columns: [taxon_id, attribute_type, attribute_measure]
+    columns:
+      attribute_measure:
+        type: string
+        nullable: true
+      attribute_type:
+        type: string
+        nullable: true
+      attribute_units:
+        type: string
+        nullable: true
+      data:
+        type: decimal
+        nullable: true
+      taxon_id:
+        required: true
+        type: integer
+        nullable: false
+    foreign_keys:
+      - entity: taxa_tree_master
+        required: true
+
+  rdb_system:
+    role: lookup
+    required: false
+    description: Definition of a Red Data Book classification system.
+    domains: [taxonomy]
+    target_table: tbl_rdb_systems
+    public_id: rdb_system_id
+    identity_columns: [location_id, rdb_system, rdb_version]
+    columns:
+      biblio_id:
+        required: true
+        type: integer
+        nullable: false
+      location_id:
+        required: true
+        type: integer
+        nullable: false
+      rdb_first_published:
+        type: integer
+        nullable: true
+      rdb_system:
+        type: string
+        nullable: true
+      rdb_system_date:
+        type: integer
+        nullable: true
+      rdb_version:
+        type: string
+        nullable: true
+      rdb_system_uuid:
+        required: true
+        type: string
+        nullable: false
+    foreign_keys:
+      - entity: citation
+        required: true
+      - entity: location
+        required: true
+
+  rdb_code:
+    role: classifier
+    required: false
+    description: Code within a Red Data Book classification system.
+    domains: [taxonomy]
+    target_table: tbl_rdb_codes
+    public_id: rdb_code_id
+    identity_columns: [rdb_system_id, rdb_category]
+    columns:
+      rdb_category:
+        type: string
+        nullable: true
+      rdb_definition:
+        type: string
+        nullable: true
+      rdb_system_id:
+        type: integer
+        nullable: true
+    unique_sets:
+      - [rdb_system_id, rdb_category]
+    foreign_keys:
+      - entity: rdb_system
+        required: false
+
+  rdb:
+    role: fact
+    required: false
+    description: Red Data Book status record for a taxon at a location.
+    aggregate_parent: taxa_tree_master
+    domains: [taxonomy]
+    target_table: tbl_rdb
+    public_id: rdb_id
+    identity_columns: [taxon_id, location_id, rdb_code_id]
+    columns:
+      location_id:
+        required: true
+        type: integer
+        nullable: false
+      rdb_code_id:
+        type: integer
+        nullable: true
+      taxon_id:
+        required: true
+        type: integer
+        nullable: false
+    foreign_keys:
+      - entity: location
+        required: true
+      - entity: rdb_code
+        required: false
       - entity: taxa_tree_master
         required: true
 

--- a/resources/target_models/sead_superset_model.yml
+++ b/resources/target_models/sead_superset_model.yml
@@ -1637,6 +1637,39 @@ entities:
     foreign_keys:
       - entity: abundance
         required: false
+      - entity: property_type
+        required: true
+
+  property_type:
+    role: classifier
+    required: false
+    description: Shared property-type vocabulary used by SEAD property tables.
+    domains: [abundance, spatial]
+    target_table: tbl_property_types
+    public_id: property_type_id
+    identity_columns: [property_type_name]
+    columns:
+      property_type_name:
+        required: true
+        type: string
+        nullable: false
+      description:
+        required: true
+        type: string
+        nullable: false
+      value_type_id:
+        type: integer
+        nullable: true
+      value_class_id:
+        type: integer
+        nullable: true
+    unique_sets:
+      - [property_type_name]
+    foreign_keys:
+      - entity: value_type
+        required: false
+      - entity: value_class
+        required: false
 
   identification_level:
     role: classifier
@@ -2131,6 +2164,62 @@ entities:
         nullable: true
     foreign_keys:
       - entity: feature_type
+        required: true
+
+  site_property:
+    role: fact
+    required: false
+    description: Property/value observation attached to a site.
+    aggregate_parent: site
+    domains: [spatial]
+    target_table: tbl_site_properties
+    public_id: site_property_id
+    identity_columns: [site_id, property_type_id, property_value]
+    columns:
+      site_id:
+        required: true
+        type: integer
+        nullable: false
+      property_type_id:
+        required: true
+        type: integer
+        nullable: false
+      property_value:
+        required: true
+        type: string
+        nullable: false
+    foreign_keys:
+      - entity: site
+        required: true
+      - entity: property_type
+        required: true
+
+  site_natgridref:
+    role: fact
+    required: false
+    description: National-grid reference attached to a site using a specific method or coordinate system.
+    aggregate_parent: site
+    domains: [spatial]
+    target_table: tbl_site_natgridrefs
+    public_id: site_natgridref_id
+    identity_columns: [site_id, method_id, natgridref]
+    columns:
+      site_id:
+        required: true
+        type: integer
+        nullable: false
+      method_id:
+        required: true
+        type: integer
+        nullable: false
+      natgridref:
+        required: true
+        type: string
+        nullable: false
+    foreign_keys:
+      - entity: site
+        required: true
+      - entity: method
         required: true
 
   sample_feature:

--- a/resources/target_models/sead_superset_model.yml
+++ b/resources/target_models/sead_superset_model.yml
@@ -1,0 +1,1386 @@
+model:
+  name: SEAD Clearinghouse Extended
+  version: 2.1.0
+  description: SEAD archaeological research data model with enhanced spatial, dating, and metadata coverage
+
+entities:
+  location:
+    role: lookup
+    required: true
+    description: Geographic location referenced by sites and other context entities.
+    domains: [core, spatial]
+    target_table: tbl_locations
+    public_id: location_id
+    identity_columns: [location_type_id, location_name]
+    columns:
+      location_name:
+        required: true
+        type: string
+        nullable: false
+      location_type_id:
+        required: true
+        type: integer
+        nullable: false
+      default_lat_dd:
+        type: decimal
+        nullable: true
+      default_long_dd:
+        type: decimal
+        nullable: true
+    unique_sets:
+      - [location_type_id, location_name]
+    foreign_keys:
+      - entity: location_type
+        required: true
+
+  location_type:
+    role: classifier
+    required: true
+    description: Controlled vocabulary for location classification.
+    domains: [core, spatial]
+    target_table: tbl_location_types
+    public_id: location_type_id
+    identity_columns: [location_type]
+    columns:
+      location_type:
+        required: true
+        type: string
+        nullable: false
+      description:
+        type: string
+        nullable: true
+    unique_sets:
+      - [location_type]
+
+  site:
+    role: lookup
+    required: true
+    description: Archaeological site anchored to a location.
+    domains: [core, spatial]
+    target_table: tbl_sites
+    public_id: site_id
+    identity_columns: [site_name]
+    columns:
+      site_name:
+        required: true
+        type: string
+        nullable: false
+      site_type_id:
+        type: integer
+        nullable: true
+      national_site_identifier:
+        type: string
+        nullable: true
+      site_description:
+        type: string
+        nullable: true
+      latitude_dd:
+        type: decimal
+        nullable: true
+      longitude_dd:
+        type: decimal
+        nullable: true
+      altitude:
+        type: decimal
+        nullable: true
+    foreign_keys:
+      - entity: location
+        required: true
+        via: site_location
+      - entity: site_type
+        required: false
+
+  site_location:
+    role: bridge
+    required: true
+    description: Join entity connecting sites to locations, allowing for many-to-many relationships between the two.
+    domains: [core, spatial]
+    target_table: tbl_site_locations
+    public_id: site_location_id
+    identity_columns: [site_id, location_id]
+    columns:
+      site_id:
+        required: true
+        type: integer
+        nullable: false
+      location_id:
+        required: true
+        type: integer
+        nullable: false
+    foreign_keys:
+      - entity: site
+        required: true
+      - entity: location
+        required: true
+        
+  site_type_group:
+    role: classifier
+    required: false
+    description: Controlled grouping for site-type vocabularies used by archaeological site classifiers.
+    domains: [core, spatial]
+    target_table: tbl_site_type_groups
+    public_id: site_type_group_id
+    identity_columns: [site_type_group]
+    columns:
+      site_type_group:
+        required: true
+        type: string
+        nullable: false
+      description:
+        type: string
+        nullable: false
+      site_type_group_abbrev:
+        type: string
+        nullable: false
+      origin_code:
+        type: string
+        nullable: true
+      origin_description:
+        type: string
+        nullable: false
+    unique_sets:
+      - [site_type_group]
+
+  site_type:
+    role: classifier
+    required: false
+    description: Controlled vocabulary for site classification in SEAD.
+    domains: [core, spatial]
+    target_table: tbl_site_types
+    public_id: site_type_id
+    identity_columns: [site_type]
+    columns:
+      site_type_group_id:
+        required: true
+        type: integer
+        nullable: false
+      site_type:
+        required: true
+        type: string
+        nullable: false
+      description:
+        type: string
+        nullable: false
+      site_type_abbrev:
+        type: string
+        nullable: false
+    foreign_keys:
+      - entity: site_type_group
+        required: false
+
+  sample_group:
+    role: lookup
+    required: true
+    description: Collection or contextual grouping that sits between site and physical samples.
+    domains: [core]
+    target_table: tbl_sample_groups
+    public_id: sample_group_id
+    identity_columns: [site_id, sample_group_name]
+    columns:
+      site_id:
+        required: true
+        type: integer
+        nullable: false
+      method_id:
+        required: true
+        type: integer
+        nullable: false
+      sample_group_name:
+        type: string
+        nullable: true
+      sample_group_description:
+        type: string
+        nullable: true
+      sampling_context_id:
+        type: integer
+        nullable: true
+    unique_sets:
+      - [site_id, sample_group_name]
+    foreign_keys:
+      - entity: site
+        required: true
+      - entity: method
+        required: true
+
+  sample:
+    role: fact
+    required: true
+    description: Core analytical specimen represented in SEAD as a physical sample.
+    domains: [core]
+    target_table: tbl_physical_samples
+    public_id: physical_sample_id
+    identity_columns: [sample_group_id, sample_name]
+    columns:
+      sample_group_id:
+        required: true
+        type: integer
+        nullable: false
+      sample_type_id:
+        required: true
+        type: integer
+        nullable: false
+      sample_name:
+        required: true
+        type: string
+        nullable: false
+      alt_ref_type_id:
+        type: integer
+        nullable: true
+      date_sampled:
+        type: string
+        nullable: true
+    unique_sets:
+      - [sample_group_id, sample_name]
+    foreign_keys:
+      - entity: sample_group
+        required: true
+      - entity: sample_type
+        required: true
+      - entity: alt_ref_type
+        required: false
+
+  sample_description_type:
+    role: classifier
+    required: false
+    description: Controlled vocabulary for typed sample descriptions.
+    domains: [core, sample-metadata]
+    target_table: tbl_sample_description_types
+    public_id: sample_description_type_id
+    identity_columns: [type_name]
+    columns:
+      type_name:
+        required: true
+        type: string
+        nullable: true
+      type_description:
+        type: string
+        nullable: true
+    unique_sets:
+      - [type_name]
+
+  sample_description:
+    role: fact
+    required: false
+    description: Typed free-text or coded description attached to a physical sample.
+    aggregate_parent: sample
+    domains: [core, sample-metadata]
+    target_table: tbl_sample_descriptions
+    public_id: sample_description_id
+    identity_columns: [physical_sample_id, sample_description_type_id]
+    columns:
+      physical_sample_id:
+        required: true
+        type: integer
+        nullable: false
+      sample_description_type_id:
+        required: true
+        type: integer
+        nullable: false
+      description:
+        type: string
+        nullable: true
+    foreign_keys:
+      - entity: sample
+        required: true
+      - entity: sample_description_type
+        required: true
+
+  sample_type:
+    role: classifier
+    required: true
+    description: Controlled vocabulary for sample classification.
+    domains: [core]
+    target_table: tbl_sample_types
+    public_id: sample_type_id
+    identity_columns: [type_name]
+    columns:
+      type_name:
+        required: true
+        type: string
+        nullable: false
+      description:
+        type: string
+        nullable: true
+    unique_sets:
+      - [type_name]
+
+  # PHASE 1 ADDITIONS - Spatial/Coordinate Domain
+
+  dimension:
+    role: classifier
+    required: false
+    description: Measurement dimension type (X, Y, Z, depth, altitude, thickness, etc.)
+    domains: [spatial, physical-properties]
+    target_table: tbl_dimensions
+    public_id: dimension_id
+    identity_columns: [dimension_abbrev]
+    columns:
+      dimension_abbrev:
+        required: true
+        type: string
+        nullable: false
+      dimension_name:
+        required: true
+        type: string
+        nullable: false
+      method_group_id:
+        type: integer
+        nullable: true
+      unit_id:
+        type: integer
+        nullable: true
+    unique_sets:
+      - [dimension_abbrev]
+    foreign_keys:
+      - entity: method_group
+        required: false
+
+  coordinate_method_dimension:
+    role: classifier
+    required: false
+    description: Coordinate measurement method with dimensional constraints
+    domains: [spatial]
+    target_table: tbl_coordinate_method_dimensions
+    public_id: coordinate_method_dimension_id
+    identity_columns: [method_id, dimension_id]
+    columns:
+      method_id:
+        required: true
+        type: integer
+        nullable: false
+      dimension_id:
+        required: true
+        type: integer
+        nullable: false
+      limit_upper:
+        type: decimal
+        nullable: true
+      limit_lower:
+        type: decimal
+        nullable: true
+    unique_sets:
+      - [method_id, dimension_id]
+    foreign_keys:
+      - entity: method
+        required: true
+      - entity: dimension
+        required: true
+
+  sample_coordinate:
+    role: fact
+    required: false
+    description: Spatial coordinate measurement for a physical sample
+    aggregate_parent: sample
+    domains: [spatial, sample-metadata]
+    target_table: tbl_sample_coordinates
+    public_id: sample_coordinate_id
+    identity_columns: [physical_sample_id, coordinate_method_dimension_id]
+    columns:
+      physical_sample_id:
+        required: true
+        type: integer
+        nullable: false
+      coordinate_method_dimension_id:
+        required: true
+        type: integer
+        nullable: false
+      measurement:
+        required: true
+        type: decimal
+        nullable: false
+      accuracy:
+        type: decimal
+        nullable: true
+    foreign_keys:
+      - entity: sample
+        required: true
+      - entity: coordinate_method_dimension
+        required: true
+
+  # PHASE 1 ADDITIONS - Sample Metadata Domain
+
+  alt_ref_type:
+    role: classifier
+    required: false
+    description: Type of alternative reference (lab number, field ID, museum number)
+    domains: [sample-metadata]
+    target_table: tbl_alt_ref_types
+    public_id: alt_ref_type_id
+    identity_columns: [alt_ref_type]
+    columns:
+      alt_ref_type:
+        required: true
+        type: string
+        nullable: false
+      description:
+        type: string
+        nullable: true
+    unique_sets:
+      - [alt_ref_type]
+
+  sample_alt_ref:
+    role: fact
+    required: false
+    description: Alternative reference identifier for a sample
+    aggregate_parent: sample
+    domains: [sample-metadata]
+    target_table: tbl_sample_alt_refs
+    public_id: sample_alt_ref_id
+    identity_columns: [physical_sample_id, alt_ref_type_id, alt_ref]
+    columns:
+      physical_sample_id:
+        required: true
+        type: integer
+        nullable: false
+      alt_ref_type_id:
+        required: true
+        type: integer
+        nullable: false
+      alt_ref:
+        required: true
+        type: string
+        nullable: false
+    unique_sets:
+      - [physical_sample_id, alt_ref_type_id, alt_ref]
+    foreign_keys:
+      - entity: sample
+        required: true
+      - entity: alt_ref_type
+        required: true
+
+  sample_dimension:
+    role: fact
+    required: false
+    description: Physical dimension measurement of a sample
+    aggregate_parent: sample
+    domains: [sample-metadata, physical-properties]
+    target_table: tbl_sample_dimensions
+    public_id: sample_dimension_id
+    identity_columns: [physical_sample_id, dimension_id, method_id]
+    columns:
+      physical_sample_id:
+        required: true
+        type: integer
+        nullable: false
+      dimension_id:
+        required: true
+        type: integer
+        nullable: false
+      method_id:
+        required: true
+        type: integer
+        nullable: false
+      dimension_value:
+        required: true
+        type: decimal
+        nullable: false
+    foreign_keys:
+      - entity: sample
+        required: true
+      - entity: dimension
+        required: true
+      - entity: method
+        required: true
+
+  method:
+    role: classifier
+    required: true
+    description: Analytical or collection method referenced by datasets.
+    reconciliation: lookup-extensible
+    domains: [core]
+    target_table: tbl_methods
+    public_id: method_id
+    identity_columns: [method_name]
+    columns:
+      method_name:
+        required: true
+        type: string
+        nullable: false
+      description:
+        required: true
+        type: string
+        nullable: false
+      method_group_id:
+        required: true
+        type: integer
+        nullable: false
+      method_abbrev_or_alt_name:
+        type: string
+        nullable: true
+      biblio_id:
+        type: integer
+        nullable: true
+    unique_sets:
+      - [method_name]
+    foreign_keys:
+      - entity: citation
+        required: false
+      - entity: method_group
+        required: false
+
+  dataset:
+    role: lookup
+    required: true
+    description: Dataset context for imported analytical observations.
+    domains: [core]
+    target_table: tbl_datasets
+    public_id: dataset_id
+    identity_columns: [dataset_name]
+    columns:
+      dataset_name:
+        required: true
+        type: string
+        nullable: false
+      data_type_id:
+        required: true
+        type: integer
+        nullable: false
+      method_id:
+        required: true
+        type: integer
+        nullable: false
+      master_set_id:
+        type: integer
+        nullable: true
+      biblio_id:
+        type: integer
+        nullable: true
+      project_id:
+        type: integer
+        nullable: true
+    unique_sets:
+      - [dataset_name]
+    foreign_keys:
+      - entity: method
+        required: true
+      - entity: master_dataset
+        required: false
+      - entity: citation
+        required: false
+      - entity: project
+        required: false
+
+  master_dataset:
+    role: lookup
+    required: false
+    description: Master dataset grouping referenced by one or more datasets.
+    domains: [core, provenance]
+    target_table: tbl_dataset_masters
+    public_id: master_set_id
+    identity_columns: [master_name]
+    columns:
+      contact_id:
+        type: integer
+        nullable: true
+      biblio_id:
+        type: integer
+        nullable: true
+      master_name:
+        required: true
+        type: string
+        nullable: true
+      master_notes:
+        type: string
+        nullable: true
+      url:
+        type: string
+        nullable: true
+    unique_sets:
+      - [master_name]
+    foreign_keys:
+      - entity: contact
+        required: false
+      - entity: citation
+        required: false
+
+  project:
+    role: lookup
+    required: false
+    description: Project-level metadata referenced by datasets and site collections.
+    domains: [core, provenance]
+    target_table: tbl_projects
+    public_id: project_id
+    identity_columns: [project_name]
+    columns:
+      project_name:
+        required: true
+        type: string
+        nullable: true
+      project_type_id:
+        type: integer
+        nullable: true
+      project_stage_id:
+        type: integer
+        nullable: true
+      project_abbrev_name:
+        type: string
+        nullable: true
+      description:
+        type: string
+        nullable: true
+    unique_sets:
+      - [project_abbrev_name]
+
+  citation:
+    role: lookup
+    required: false
+    description: Bibliographic reference reused by datasets, methods, and other SEAD entities.
+    reconciliation: reconcile-fuzzy
+    domains: [provenance, bibliography]
+    target_table: tbl_biblio
+    public_id: biblio_id
+    identity_columns: [title, year, authors]
+    columns:
+      bugs_reference:
+        type: string
+        nullable: true
+      doi:
+        type: string
+        nullable: true
+      isbn:
+        type: string
+        nullable: true
+      notes:
+        type: string
+        nullable: true
+      title:
+        type: string
+        nullable: true
+      year:
+        type: string
+        nullable: true
+      authors:
+        type: string
+        nullable: true
+      full_reference:
+        type: string
+        nullable: false
+      url:
+        type: string
+        nullable: true
+
+  analysis_entity:
+    role: bridge
+    required: true
+    description: Analytical observation context connecting sample and dataset.
+    identity_tracking: tracked
+    reconciliation: allocate
+    domains: [core]
+    target_table: tbl_analysis_entities
+    public_id: analysis_entity_id
+    columns:
+      physical_sample_id:
+        required: true
+        type: integer
+        nullable: false
+      dataset_id:
+        required: true
+        type: integer
+        nullable: false
+    foreign_keys:
+      - entity: sample
+        required: true
+      - entity: dataset
+        required: true
+
+  abundance:
+    role: fact
+    required: false
+    description: Biological abundance observation linked to an analysis entity and typically to a taxon.
+    aggregate_parent: analysis_entity
+    domains: [abundance, taxonomy]
+    target_table: tbl_abundances
+    public_id: abundance_id
+    identity_columns: [analysis_entity_id, taxon_id]
+    columns:
+      analysis_entity_id:
+        required: true
+        type: integer
+        nullable: false
+      taxon_id:
+        type: integer
+        nullable: false
+      abundance_element_id:
+        type: integer
+        nullable: true
+      abundance:
+        required: true
+        type: integer
+        nullable: false
+    foreign_keys:
+      - entity: analysis_entity
+        required: true
+      - entity: abundance_element
+        required: false
+      - entity: taxa_tree_master
+        required: true
+
+  abundance_element:
+    role: classifier
+    required: false
+    description: Controlled vocabulary for the element or remain type attached to an abundance observation.
+    reconciliation: lookup-extensible
+    domains: [abundance]
+    target_table: tbl_abundance_elements
+    public_id: abundance_element_id
+    identity_columns: [element_name]
+    columns:
+      element_name:
+        required: true
+        type: string
+        nullable: false
+      record_type_id:
+        type: integer
+        nullable: true
+      element_description:
+        type: string
+        nullable: true
+
+  abundance_element_group:
+    role: classifier
+    required: false
+    description: Common project-side grouping vocabulary for abundance elements used during SEAD abundance preparation.
+    domains: [abundance]
+    public_id: abundance_element_group_id
+    identity_columns: [abundance_element_group_name]
+    columns:
+      abundance_element_group_name:
+        required: true
+        type: string
+        nullable: false
+      description:
+        type: string
+        nullable: true
+
+  abundance_modification:
+    role: bridge
+    required: false
+    description: Join entity linking an abundance record to one or more modification types.
+    domains: [abundance]
+    target_table: tbl_abundance_modifications
+    public_id: abundance_modification_id
+    identity_columns: [abundance_id, modification_type_id]
+    columns:
+      abundance_id:
+        required: true
+        type: integer
+        nullable: false
+      modification_type_id:
+        required: true
+        type: integer
+        nullable: false
+    foreign_keys:
+      - entity: abundance
+        required: false
+      - entity: modification_type
+        required: true
+
+  modification_type:
+    role: classifier
+    required: false
+    description: Controlled vocabulary for abundance and specimen modification states.
+    domains: [abundance]
+    target_table: tbl_modification_types
+    public_id: modification_type_id
+    identity_columns: [modification_type_name]
+    columns:
+      modification_type_name:
+        required: true
+        type: string
+        nullable: true
+      modification_type_description:
+        type: string
+        nullable: true
+    unique_sets:
+      - [modification_type_name]
+
+  abundance_property:
+    role: fact
+    required: false
+    description: Property/value observation attached to an abundance record.
+    aggregate_parent: abundance
+    domains: [abundance]
+    target_table: tbl_abundance_properties
+    public_id: abundance_property_id
+    identity_columns: [abundance_id, property_type_id, property_value]
+    columns:
+      abundance_id:
+        required: true
+        type: integer
+        nullable: false
+      property_type_id:
+        type: integer
+        nullable: false
+      property_value:
+        type: string
+        nullable: false
+    foreign_keys:
+      - entity: abundance
+        required: false
+
+  identification_level:
+    role: classifier
+    required: false
+    description: Taxonomic identification confidence level (Family, Genus, Species, cf. X)
+    domains: [taxonomy, abundance]
+    target_table: tbl_identification_levels
+    public_id: identification_level_id
+    identity_columns: [identification_level_abbrev]
+    columns:
+      identification_level_abbrev:
+        required: true
+        type: string
+        nullable: false
+      identification_level_name:
+        required: true
+        type: string
+        nullable: false
+      notes:
+        type: string
+        nullable: true
+    unique_sets:
+      - [identification_level_abbrev]
+
+  abundance_ident_level:
+    role: bridge
+    required: false
+    description: Links abundance records to identification confidence levels
+    domains: [taxonomy, abundance]
+    target_table: tbl_abundance_ident_levels
+    public_id: abundance_ident_level_id
+    identity_columns: [abundance_id, identification_level_id]
+    columns:
+      abundance_id:
+        required: true
+        type: integer
+        nullable: false
+      identification_level_id:
+        required: true
+        type: integer
+        nullable: false
+    unique_sets:
+      - [abundance_id, identification_level_id]
+    foreign_keys:
+      - entity: abundance
+        required: true
+      - entity: identification_level
+        required: true
+
+  taxa_tree_master:
+    role: classifier
+    required: false
+    description: Canonical SEAD taxonomy entity referenced by abundance and other taxon-linked observations.
+    reconciliation: lookup-extensible
+    domains: [taxonomy]
+    target_table: tbl_taxa_tree_master
+    public_id: taxon_id
+    identity_columns: [genus_id, species]
+    columns:
+      genus_id:
+        required: true
+        type: integer
+        nullable: true
+      species:
+        required: true
+        type: string
+        nullable: true
+      author_id:
+        type: integer
+        nullable: true
+
+  taxa_common_names:
+    role: lookup
+    required: false
+    description: Human-readable taxon names associated with SEAD taxonomy records.
+    aggregate_parent: taxa_tree_master
+    domains: [taxonomy]
+    target_table: tbl_taxa_common_names
+    public_id: taxon_common_name_id
+    identity_columns: [taxon_id, common_name]
+    columns:
+      taxon_id:
+        required: true
+        type: integer
+        nullable: true
+      common_name:
+        required: true
+        type: string
+        nullable: true
+      language_id:
+        type: integer
+        nullable: true
+    foreign_keys:
+      - entity: taxa_tree_master
+        required: true
+
+  # PHASE 1 ADDITIONS - Dating Domain
+
+  age_type:
+    role: classifier
+    required: false
+    description: Chronological notation system (AD, BC, BP, cal BP)
+    domains: [dating]
+    target_table: tbl_age_types
+    public_id: age_type_id
+    identity_columns: [age_type]
+    columns:
+      age_type:
+        required: true
+        type: string
+        nullable: false
+      description:
+        type: string
+        nullable: true
+    unique_sets:
+      - [age_type]
+
+  relative_age_type:
+    role: classifier
+    required: false
+    description: Type of relative age system (archaeological period, geological epoch)
+    domains: [dating]
+    target_table: tbl_relative_age_types
+    public_id: relative_age_type_id
+    identity_columns: [age_type]
+    columns:
+      age_type:
+        required: true
+        type: string
+        nullable: true
+      description:
+        type: string
+        nullable: true
+    unique_sets:
+      - [age_type]
+
+  chronology:
+    role: lookup
+    required: false
+    description: Chronological framework or dating system
+    domains: [dating]
+    target_table: tbl_chronologies
+    public_id: chronology_id
+    identity_columns: [chronology_name]
+    columns:
+      chronology_name:
+        required: true
+        type: string
+        nullable: false
+      location_id:
+        type: integer
+        nullable: true
+      notes:
+        type: string
+        nullable: true
+    unique_sets:
+      - [chronology_name]
+    foreign_keys:
+      - entity: location
+        required: false
+
+  dating_uncertainty:
+    role: classifier
+    required: false
+    description: Uncertainty qualifiers for dating results
+    domains: [dating]
+    target_table: tbl_dating_uncertainty
+    public_id: dating_uncertainty_id
+    identity_columns: [uncertainty]
+    columns:
+      uncertainty:
+        required: true
+        type: string
+        nullable: false
+    unique_sets:
+      - [uncertainty]
+
+  dating_material:
+    role: lookup
+    required: false
+    description: Material dated in geochronological analysis
+    domains: [dating]
+    target_table: tbl_dating_material
+    public_id: dating_material_id
+    identity_columns: [dating_material_name]
+    columns:
+      dating_material_name:
+        required: true
+        type: string
+        nullable: false
+      description:
+        type: string
+        nullable: true
+      abundance_element_id:
+        type: integer
+        nullable: true
+    unique_sets:
+      - [dating_material_name]
+    foreign_keys:
+      - entity: abundance_element
+        required: false
+
+  relative_ages:
+    role: lookup
+    required: false
+    description: Controlled relative-age vocabulary used by archaeological dating records.
+    domains: [dating]
+    target_table: tbl_relative_ages
+    public_id: relative_age_id
+    identity_columns: [relative_age_name]
+    columns:
+      relative_age_name:
+        required: true
+        type: string
+        nullable: true
+      relative_age_type_id:
+        type: integer
+        nullable: true
+      description:
+        type: string
+        nullable: true
+      c14_age_older:
+        type: decimal
+        nullable: true
+      c14_age_younger:
+        type: decimal
+        nullable: true
+      cal_age_older:
+        type: decimal
+        nullable: true
+      cal_age_younger:
+        type: decimal
+        nullable: true
+      notes:
+        type: string
+        nullable: true
+      location_id:
+        type: integer
+        nullable: true
+      abbreviation:
+        type: string
+        nullable: true
+    foreign_keys:
+      - entity: relative_age_type
+        required: false
+      - entity: location
+        required: false
+
+  relative_dating:
+    role: fact
+    required: false
+    description: Relative or archaeological dating observation linked to an analysis entity and optionally to a relative age vocabulary entry; Arbodat archaeological dating facts map here.
+    aggregate_parent: analysis_entity
+    domains: [dating]
+    target_table: tbl_relative_dates
+    public_id: relative_date_id
+    identity_columns: [analysis_entity_id, relative_age_id]
+    columns:
+      analysis_entity_id:
+        required: true
+        type: integer
+        nullable: false
+      relative_age_id:
+        type: integer
+        nullable: true
+      method_id:
+        type: integer
+        nullable: true
+      notes:
+        type: string
+        nullable: true
+      dating_uncertainty_id:
+        type: integer
+        nullable: true
+    foreign_keys:
+      - entity: analysis_entity
+        required: true
+      - entity: relative_ages
+        required: false
+      - entity: method
+        required: false
+      - entity: dating_uncertainty
+        required: false
+
+  geochronology:
+    role: fact
+    required: false
+    description: Absolute or chronology dating observation linked to an analysis entity and optionally to a dating laboratory; Arbodat chronology/lab dating facts map here even when the project-local entity is named `dating`.
+    aggregate_parent: analysis_entity
+    domains: [dating]
+    target_table: tbl_geochronology
+    public_id: geochron_id
+    identity_columns: [analysis_entity_id, lab_number]
+    columns:
+      analysis_entity_id:
+        required: true
+        type: integer
+        nullable: false
+      dating_lab_id:
+        type: integer
+        nullable: true
+      lab_number:
+        type: string
+        nullable: true
+      age:
+        type: decimal
+        nullable: true
+      error_older:
+        type: decimal
+        nullable: true
+      error_younger:
+        type: decimal
+        nullable: true
+      delta_13c:
+        type: decimal
+        nullable: true
+      notes:
+        type: string
+        nullable: true
+      dating_uncertainty_id:
+        type: integer
+        nullable: true
+    foreign_keys:
+      - entity: analysis_entity
+        required: true
+      - entity: dating_lab
+        required: false
+      - entity: dating_uncertainty
+        required: false
+
+  dating_lab:
+    role: lookup
+    required: false
+    description: Laboratory metadata for dated samples and geochronology results.
+    domains: [dating]
+    target_table: tbl_dating_labs
+    public_id: dating_lab_id
+    identity_columns: [international_lab_id]
+    columns:
+      international_lab_id:
+        required: true
+        type: string
+        nullable: false
+      lab_name:
+        type: string
+        nullable: true
+      contact_id:
+        type: integer
+        nullable: true
+      country_id:
+        type: integer
+        nullable: true
+
+  method_group:
+    role: classifier
+    required: false
+    description: Controlled grouping for analytical and collection methods.
+    domains: [core, contacts]
+    target_table: tbl_method_groups
+    public_id: method_group_id
+    identity_columns: [group_name]
+    columns:
+      group_name:
+        required: true
+        type: string
+        nullable: false
+      description:
+        required: true
+        type: string
+        nullable: false
+    unique_sets:
+      - [group_name]
+
+  contact:
+    role: lookup
+    required: false
+    description: Person or organization contact metadata used by datasets, projects, and dating laboratories.
+    reconciliation: lookup-only
+    domains: [contacts]
+    target_table: tbl_contacts
+    public_id: contact_id
+    columns:
+      first_name:
+        type: string
+        nullable: true
+      last_name:
+        type: string
+        nullable: true
+      email:
+        type: string
+        nullable: true
+      phone_number:
+        type: string
+        nullable: true
+      address_1:
+        type: string
+        nullable: true
+      address_2:
+        type: string
+        nullable: true
+      location_id:
+        type: integer
+        nullable: true
+      url:
+        type: string
+        nullable: true
+
+  contact_type:
+    role: classifier
+    required: false
+    description: Controlled vocabulary describing a contact's role in a dataset or project context.
+    domains: [contacts]
+    target_table: tbl_contact_types
+    public_id: contact_type_id
+    identity_columns: [contact_type_name]
+    columns:
+      contact_type_name:
+        type: string
+        nullable: false
+      description:
+        type: string
+        nullable: true
+    unique_sets:
+      - [contact_type_name]
+
+  dataset_contact:
+    role: bridge
+    required: false
+    description: Many-to-many bridge connecting datasets, contacts, and contact roles.
+    domains: [contacts, provenance]
+    target_table: tbl_dataset_contacts
+    public_id: dataset_contact_id
+    identity_columns: [dataset_id, contact_id, contact_type_id]
+    columns:
+      dataset_id:
+        required: true
+        type: integer
+        nullable: false
+      contact_id:
+        required: true
+        type: integer
+        nullable: false
+      contact_type_id:
+        required: true
+        type: integer
+        nullable: false
+    foreign_keys:
+      - entity: dataset
+        required: true
+      - entity: contact
+        required: true
+      - entity: contact_type
+        required: true
+
+  feature_type:
+    role: classifier
+    required: false
+    description: Controlled vocabulary for archaeological feature classification.
+    domains: [core, excavation]
+    target_table: tbl_feature_types
+    public_id: feature_type_id
+    identity_columns: [feature_type_name]
+    columns:
+      feature_type_name:
+        required: true
+        type: string
+        nullable: true
+      feature_type_description:
+        type: string
+        nullable: true
+    unique_sets:
+      - [feature_type_name]
+
+  feature:
+    role: lookup
+    required: false
+    description: Archaeological feature or excavation context referenced by samples and site workflows.
+    domains: [core, excavation]
+    target_table: tbl_features
+    public_id: feature_id
+    identity_columns: [feature_type_id, feature_name]
+    columns:
+      feature_type_id:
+        required: true
+        type: integer
+        nullable: false
+      feature_name:
+        type: string
+        nullable: true
+      feature_description:
+        type: string
+        nullable: true
+    foreign_keys:
+      - entity: feature_type
+        required: true
+
+  sample_feature:
+    role: bridge
+    required: false
+    description: Many-to-many bridge connecting physical samples to archaeological features.
+    domains: [core, excavation]
+    target_table: tbl_physical_sample_features
+    public_id: physical_sample_feature_id
+    identity_columns: [physical_sample_id, feature_id]
+    columns:
+      physical_sample_id:
+        required: true
+        type: integer
+        nullable: false
+      feature_id:
+        required: true
+        type: integer
+        nullable: false
+    foreign_keys:
+      - entity: sample
+        required: true
+      - entity: feature
+        required: true
+
+  data_type:
+    role: classifier
+    required: false
+    description: Controlled vocabulary for the type of data produced by an analytical method.
+    domains: [core]
+    target_table: tbl_data_types
+    public_id: data_type_id
+    identity_columns: [data_type_name]
+    columns:
+      data_type_name:
+        required: true
+        type: string
+        nullable: false
+      definition:
+        type: string
+        nullable: true
+    unique_sets:
+      - [data_type_name]
+
+  unit:
+    role: classifier
+    required: false
+    description: Unit of measurement referenced by dimensions, methods, and analytical values.
+    domains: [core]
+    target_table: tbl_units
+    public_id: unit_id
+    identity_columns: [unit_name]
+    columns:
+      unit_name:
+        required: true
+        type: string
+        nullable: false
+      unit_abbrev:
+        type: string
+        nullable: true
+      description:
+        type: string
+        nullable: true
+    unique_sets:
+      - [unit_name]
+      - [unit_abbrev]
+
+naming:
+  public_id_suffix: _id
+
+constraints:
+  - type: no_orphan_facts
+  - type: no_circular_dependencies

--- a/resources/target_models/sead_superset_model.yml
+++ b/resources/target_models/sead_superset_model.yml
@@ -2194,6 +2194,34 @@ entities:
       - entity: property_type
         required: true
 
+  feature_property:
+    role: fact
+    required: false
+    description: Property/value observation attached to an archaeological feature.
+    aggregate_parent: feature
+    domains: [excavation]
+    target_table: tbl_feature_properties
+    public_id: feature_property_id
+    identity_columns: [feature_id, property_type_id, property_value]
+    columns:
+      feature_id:
+        required: true
+        type: integer
+        nullable: false
+      property_type_id:
+        required: true
+        type: integer
+        nullable: false
+      property_value:
+        required: true
+        type: string
+        nullable: false
+    foreign_keys:
+      - entity: feature
+        required: true
+      - entity: property_type
+        required: true
+
   site_natgridref:
     role: fact
     required: false

--- a/resources/target_models/sead_superset_model.yml
+++ b/resources/target_models/sead_superset_model.yml
@@ -598,6 +598,108 @@ entities:
       - entity: value_qualifier
         required: true
 
+  value_type:
+    role: classifier
+    required: false
+    description: Value-type definition describing the base storage shape and optional unit for analytical values.
+    domains: [analysis]
+    target_table: tbl_value_types
+    public_id: value_type_id
+    identity_columns: [name]
+    columns:
+      unit_id:
+        type: integer
+        nullable: true
+      data_type_id:
+        type: integer
+        nullable: true
+      name:
+        required: true
+        type: string
+        nullable: false
+      base_type:
+        required: true
+        type: string
+        nullable: false
+      precision:
+        type: integer
+        nullable: true
+      description:
+        required: true
+        type: string
+        nullable: false
+    unique_sets:
+      - [name]
+    foreign_keys:
+      - entity: unit
+        required: false
+      - entity: data_type
+        required: false
+
+  value_type_item:
+    role: classifier
+    required: false
+    description: Category value attached to a categorical value type.
+    domains: [analysis]
+    target_table: tbl_value_type_items
+    public_id: value_type_item_id
+    identity_columns: [value_type_id, name]
+    columns:
+      value_type_id:
+        required: true
+        type: integer
+        nullable: false
+      name:
+        required: true
+        type: string
+        nullable: false
+      description:
+        type: string
+        nullable: true
+    unique_sets:
+      - [value_type_id, name]
+    foreign_keys:
+      - entity: value_type
+        required: true
+
+  value_class:
+    role: classifier
+    required: false
+    description: Analytical value class describing a data column or measurement family.
+    domains: [analysis]
+    target_table: tbl_value_classes
+    public_id: value_class_id
+    identity_columns: [value_type_id, method_id, name]
+    columns:
+      value_type_id:
+        required: true
+        type: integer
+        nullable: false
+      method_id:
+        required: true
+        type: integer
+        nullable: false
+      parent_id:
+        type: integer
+        nullable: true
+      name:
+        required: true
+        type: string
+        nullable: false
+      description:
+        required: true
+        type: string
+        nullable: false
+    unique_sets:
+      - [value_type_id, method_id, name]
+    foreign_keys:
+      - entity: value_type
+        required: true
+      - entity: method
+        required: true
+      - entity: value_class
+        required: false
+
   sample_alt_ref:
     role: fact
     required: false
@@ -1011,8 +1113,9 @@ entities:
         type: integer
         nullable: false
       value_class_id:
+        required: true
         type: integer
-        nullable: true
+        nullable: false
       analysis_value:
         type: string
         nullable: true
@@ -1039,6 +1142,8 @@ entities:
         nullable: true
     foreign_keys:
       - entity: analysis_entity
+        required: true
+      - entity: value_class
         required: true
 
   analysis_note:
@@ -1112,6 +1217,36 @@ entities:
         nullable: false
     foreign_keys:
       - entity: analysis_value
+        required: true
+
+  analysis_categorical_value:
+    role: fact
+    required: false
+    description: Categorical analysis result linked to a controlled value-type item.
+    aggregate_parent: analysis_value
+    domains: [analysis]
+    target_table: tbl_analysis_categorical_values
+    public_id: analysis_categorical_value_id
+    identity_columns: [analysis_value_id, value_type_item_id]
+    columns:
+      analysis_value_id:
+        required: true
+        type: integer
+        nullable: false
+      value_type_item_id:
+        required: true
+        type: integer
+        nullable: false
+      value:
+        type: decimal
+        nullable: true
+      is_variant:
+        type: boolean
+        nullable: true
+    foreign_keys:
+      - entity: analysis_value
+        required: true
+      - entity: value_type_item
         required: true
 
   analysis_integer_value:
@@ -1208,6 +1343,45 @@ entities:
         required: true
         type: decimal
         nullable: false
+      is_variant:
+        type: boolean
+        nullable: true
+    foreign_keys:
+      - entity: analysis_value
+        required: true
+      - entity: value_qualifier_symbol
+        required: false
+
+  analysis_numerical_range:
+    role: fact
+    required: false
+    description: Numerical range stored in the SEAD `numrange` column format and attached to an analysis value.
+    aggregate_parent: analysis_value
+    domains: [analysis]
+    target_table: tbl_analysis_numerical_ranges
+    public_id: analysis_numerical_range_id
+    identity_columns: [analysis_value_id, value, low_qualifier, high_qualifier]
+    columns:
+      analysis_value_id:
+        required: true
+        type: integer
+        nullable: false
+      value:
+        required: true
+        type: numrange
+        nullable: false
+      low_is_uncertain:
+        type: boolean
+        nullable: true
+      high_is_uncertain:
+        type: boolean
+        nullable: true
+      low_qualifier:
+        type: string
+        nullable: true
+      high_qualifier:
+        type: string
+        nullable: true
       is_variant:
         type: boolean
         nullable: true

--- a/scripts/generate_target_model_docs.py
+++ b/scripts/generate_target_model_docs.py
@@ -58,27 +58,31 @@ def main():
         epilog="""
 Output formats
 --------------
-  html      Interactive web page with entity cards, live search, domain groupings,
-            and relationship arrows. Recommended for stakeholder presentations and
-            reference documentation. Opens in any browser; no software required.
+    html      Interactive web page with entity cards, live search, domain groupings,
+                        and relationship arrows. Recommended for stakeholder presentations and
+                        reference documentation. Opens in any browser; no software required.
 
-  excel     Excel workbook with three sheets (Entities, Columns, Relationships).
-            Sortable and filterable. Best for review workshops, gap analysis, and
-            collecting structured feedback. Add review columns ("Complete?",
-            "Priority", "Comments") and distribute to domain experts.
+    excel     Excel workbook with three sheets (Entities, Columns, Relationships).
+                        Sortable and filterable. Best for review workshops, gap analysis, and
+                        collecting structured feedback. Add review columns ("Complete?",
+                        "Priority", "Comments") and distribute to domain experts.
 
-  markdown  Plain-text Markdown grouped by domain. Renders on GitHub/GitLab.
-            Version-controlled and can be converted to PDF or Word.
+    markdown  Plain-text Markdown grouped by domain. Renders on GitHub/GitLab.
+                        Version-controlled and can be converted to PDF or Word.
 
-  all       Generates all three formats in one pass (default).
+    sims      Markdown register focused on SIMS identity categories, aggregate
+                        boundaries, business keys, and reconciliation strategy groupings.
+
+    all       Generates every supported format in one pass (default).
 
 Output files
 ------------
   Files are written to --output-dir (default: docs/generated/) using the input
   file stem as the base name, e.g.:
-    docs/generated/sead_standard_model.html
-    docs/generated/sead_standard_model.md
-    docs/generated/sead_standard_model.xlsx
+    docs/generated/sead_superset_model.html
+    docs/generated/sead_superset_model.md
+    docs/generated/sead_superset_model.xlsx
+    docs/generated/sead_superset_model.sims.md
 
 Understanding entity cards (HTML)
 ----------------------------------
@@ -104,13 +108,16 @@ Understanding entity cards (HTML)
 Examples
 --------
   # Generate all formats from the bundled SEAD spec
-  python scripts/generate_target_model_docs.py resources/target_models/sead_standard_model.yml
+    python scripts/generate_target_model_docs.py resources/target_models/sead_superset_model.yml
 
   # HTML only (recommended for stakeholder review)
-  python scripts/generate_target_model_docs.py resources/target_models/sead_standard_model.yml --format html
+    python scripts/generate_target_model_docs.py resources/target_models/sead_superset_model.yml --format html
 
   # Excel for gap-analysis workshop
-  python scripts/generate_target_model_docs.py resources/target_models/sead_standard_model.yml --format excel
+    python scripts/generate_target_model_docs.py resources/target_models/sead_superset_model.yml --format excel
+
+    # SIMS entity register for the Authority Service docs
+    python scripts/generate_target_model_docs.py resources/target_models/sead_superset_model.yml --format sims --output-dir /tmp
 
   # Custom output directory
   python scripts/generate_target_model_docs.py my_model.yml --format all --output-dir /tmp/model-docs
@@ -119,9 +126,9 @@ Examples
     parser.add_argument("input", type=Path, help="Input YAML file (e.g., resources/target_models/sead_standard_model.yml)")
     parser.add_argument(
         "--format",
-        choices=["html", "markdown", "excel", "all"],
+        choices=["html", "markdown", "excel", "sims", "all"],
         default="all",
-        help="Output format: html (interactive), markdown (plain text), excel (spreadsheet), all (default)",
+        help="Output format: html (interactive), markdown (plain text), excel (spreadsheet), sims (identity register), all (default)",
     )
     parser.add_argument("--output-dir", type=Path, default=Path("docs/generated"), help="Output directory (default: docs/generated)")
 
@@ -147,7 +154,7 @@ Examples
     # Generate requested formats
     formats_to_generate = []
     if args.format == "all":
-        formats_to_generate = [DocumentFormat.HTML, DocumentFormat.MARKDOWN, DocumentFormat.EXCEL]
+        formats_to_generate = [DocumentFormat.HTML, DocumentFormat.MARKDOWN, DocumentFormat.EXCEL, DocumentFormat.SIMS]
     else:
         formats_to_generate = [DocumentFormat(args.format)]
 
@@ -156,6 +163,7 @@ Examples
             DocumentFormat.HTML: "html",
             DocumentFormat.MARKDOWN: "md",
             DocumentFormat.EXCEL: "xlsx",
+            DocumentFormat.SIMS: "sims.md",
         }
         output_path = args.output_dir / f"{base_name}.{extensions[doc_format]}"
 

--- a/src/target_model/models.py
+++ b/src/target_model/models.py
@@ -2,16 +2,20 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ForeignKeySpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     entity: str
     required: bool = False
     via: str | None = None  # Bridge entity name for many-to-many relationships
 
 
 class ColumnSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     required: bool = False
     type: str | None = None
     nullable: bool | None = None
@@ -19,6 +23,8 @@ class ColumnSpec(BaseModel):
 
 
 class EntitySpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     role: Literal["fact", "lookup", "classifier", "bridge"] | None = None
     required: bool = False
     description: str | None = None
@@ -37,20 +43,28 @@ class EntitySpec(BaseModel):
 
 
 class NamingConventions(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     public_id_suffix: str | None = None
 
 
 class GlobalConstraint(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     type: str
 
 
 class ModelMetadata(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     name: str
     version: str
     description: str | None = None
 
 
 class TargetModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     model: ModelMetadata
     entities: dict[str, EntitySpec] = Field(default_factory=dict)
     naming: NamingConventions | None = None

--- a/src/target_model/spec_validator.py
+++ b/src/target_model/spec_validator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from src.issues import CoreIssue
-from src.target_model.models import TargetModel
+from src.target_model.models import EntitySpec, TargetModel
 
 
 @dataclass(slots=True, kw_only=True, repr=False)
@@ -66,5 +66,159 @@ class TargetModelSpecValidator:
                                 entity=entity_name,
                             )
                         )
+
+            issues.extend(self._validate_aggregate_parent(target_model, entity_name, entity_spec))
+            issues.extend(self._validate_identity_rules(entity_name, entity_spec))
+
+        return issues
+
+    @staticmethod
+    def _resolve_effective_sims(spec: EntitySpec) -> tuple[str | None, str | None]:
+        identity_tracking: str | None = spec.identity_tracking
+        reconciliation: str | None = spec.reconciliation
+
+        if identity_tracking is None:
+            if spec.aggregate_parent:
+                identity_tracking = "child"
+            elif spec.role == "fact":
+                identity_tracking = "tracked"
+            elif spec.role in ("lookup", "classifier"):
+                identity_tracking = "reconciled"
+            elif spec.role == "bridge":
+                identity_tracking = "derived"
+
+        if reconciliation is None:
+            if identity_tracking == "tracked":
+                reconciliation = "allocate"
+            elif spec.role == "lookup":
+                reconciliation = "reconcile-exact"
+            elif spec.role == "classifier":
+                reconciliation = "lookup-only"
+            elif identity_tracking == "derived":
+                reconciliation = "derive"
+
+        return identity_tracking, reconciliation
+
+    def _validate_aggregate_parent(self, target_model: TargetModel, entity_name: str, entity_spec: EntitySpec) -> list[SpecValidationIssue]:
+        issues: list[SpecValidationIssue] = []
+        aggregate_parent = entity_spec.aggregate_parent
+
+        if aggregate_parent is None:
+            if entity_spec.identity_tracking == "child":
+                issues.append(
+                    SpecValidationIssue(
+                        code="CHILD_IDENTITY_MISSING_AGGREGATE_PARENT",
+                        message=f"Entity '{entity_name}' declares identity_tracking 'child' but has no aggregate_parent",
+                        entity=entity_name,
+                    )
+                )
+            return issues
+
+        if aggregate_parent == entity_name:
+            issues.append(
+                SpecValidationIssue(
+                    code="SELF_REFERENTIAL_AGGREGATE_PARENT",
+                    message=f"Entity '{entity_name}' cannot use itself as aggregate_parent",
+                    entity=entity_name,
+                )
+            )
+            return issues
+
+        if aggregate_parent not in target_model.entities:
+            issues.append(
+                SpecValidationIssue(
+                    code="UNKNOWN_AGGREGATE_PARENT",
+                    message=f"Entity '{entity_name}' references unknown aggregate_parent '{aggregate_parent}'",
+                    entity=entity_name,
+                )
+            )
+            return issues
+
+        if entity_spec.identity_tracking is not None and entity_spec.identity_tracking != "child":
+            issues.append(
+                SpecValidationIssue(
+                    code="AGGREGATE_PARENT_CONFLICTS_WITH_IDENTITY_TRACKING",
+                    message=(
+                        f"Entity '{entity_name}' uses aggregate_parent '{aggregate_parent}' but declares "
+                        f"identity_tracking '{entity_spec.identity_tracking}' instead of 'child'"
+                    ),
+                    entity=entity_name,
+                )
+            )
+
+        foreign_key_targets = {foreign_key.entity for foreign_key in entity_spec.foreign_keys}
+        if aggregate_parent not in foreign_key_targets:
+            issues.append(
+                SpecValidationIssue(
+                    code="MISSING_AGGREGATE_PARENT_FOREIGN_KEY",
+                    message=(
+                        f"Entity '{entity_name}' uses aggregate_parent '{aggregate_parent}' but does not declare a foreign key to it"
+                    ),
+                    entity=entity_name,
+                )
+            )
+
+        return issues
+
+    def _validate_identity_rules(self, entity_name: str, entity_spec: EntitySpec) -> list[SpecValidationIssue]:
+        issues: list[SpecValidationIssue] = []
+        identity_tracking, reconciliation = self._resolve_effective_sims(entity_spec)
+
+        if identity_tracking == "child":
+            if entity_spec.reconciliation is not None:
+                issues.append(
+                    SpecValidationIssue(
+                        code="INVALID_IDENTITY_RECONCILIATION_COMBINATION",
+                        message=(
+                            f"Entity '{entity_name}' uses child identity via aggregate_parent and must not declare "
+                            f"reconciliation '{entity_spec.reconciliation}'"
+                        ),
+                        entity=entity_name,
+                    )
+                )
+            return issues
+
+        if identity_tracking == "tracked" and reconciliation != "allocate":
+            issues.append(
+                SpecValidationIssue(
+                    code="INVALID_IDENTITY_RECONCILIATION_COMBINATION",
+                    message=(
+                        f"Entity '{entity_name}' uses tracked identity and must resolve to reconciliation 'allocate', "
+                        f"not '{reconciliation}'"
+                    ),
+                    entity=entity_name,
+                )
+            )
+            return issues
+
+        if identity_tracking == "derived" and reconciliation != "derive":
+            issues.append(
+                SpecValidationIssue(
+                    code="INVALID_IDENTITY_RECONCILIATION_COMBINATION",
+                    message=(
+                        f"Entity '{entity_name}' uses derived identity and must resolve to reconciliation 'derive', "
+                        f"not '{reconciliation}'"
+                    ),
+                    entity=entity_name,
+                )
+            )
+            return issues
+
+        if identity_tracking == "reconciled" and reconciliation not in {
+            "reconcile-exact",
+            "reconcile-fuzzy",
+            "lookup-only",
+            "lookup-extensible",
+        }:
+            issues.append(
+                SpecValidationIssue(
+                    code="INVALID_IDENTITY_RECONCILIATION_COMBINATION",
+                    message=(
+                        f"Entity '{entity_name}' uses reconciled identity and must resolve to a lookup or reconcile strategy, "
+                        f"not '{reconciliation}'"
+                    ),
+                    entity=entity_name,
+                )
+            )
 
         return issues

--- a/src/target_model/templates/sims_entity_register.md.j2
+++ b/src/target_model/templates/sims_entity_register.md.j2
@@ -1,6 +1,8 @@
 # SIMS Entity Register
 
 > Auto-generated from {{ model.name }} v{{ model.version }}
+>
+> This register reflects target-model metadata. Compare it with `config/identity_policy.yml` when reviewing current Authority Service rollout state.
 
 ## Summary
 
@@ -33,10 +35,10 @@ Controlled vocabularies maintained by SEAD administrators; providers reference e
 Association entities whose identity is derived from their foreign key references.
 {% endif %}
 
-| Entity | Role | Reconciliation | Aggregate Parent | Domains |
-|--------|------|----------------|------------------|---------|
+| Entity | Target Table | Role | Business Key | Required | Reconciliation | Aggregate Parent | Domains |
+|--------|--------------|------|--------------|----------|----------------|------------------|---------|
 {% for e in group_entities %}
-| {{ e.name }} | {{ e.spec.role or '-' }} | {{ e.reconciliation or '-' }} | {{ e.aggregate_parent or '-' }} | {{ e.spec.domains|join(', ') }} |
+| {{ e.name }} | {{ e.spec.target_table or '-' }} | {{ e.spec.role or '-' }} | {{ e.spec.identity_columns|join(', ') or '-' }} | {{ 'yes' if e.spec.required else 'no' }} | {{ e.reconciliation or '-' }} | {{ e.aggregate_parent or '-' }} | {{ e.spec.domains|join(', ') or '-' }} |
 {% endfor %}
 
 {% endif %}

--- a/tests/model/test_target_model_conformance.py
+++ b/tests/model/test_target_model_conformance.py
@@ -288,6 +288,32 @@ def test_core_conformance_accepts_sample_note_example_fixture() -> None:
     assert issue_pairs(target_model, project) == []
 
 
+def test_core_conformance_accepts_sample_group_note_example_fixture() -> None:
+    target_model: TargetModel = _minimal_target_model(
+        {
+            "sample_group": {
+                "required": True,
+                "public_id": "sample_group_id",
+                "columns": {
+                    "sample_group_name": {"required": True},
+                },
+            },
+            "sample_group_note": {
+                "required": False,
+                "public_id": "sample_group_note_id",
+                "columns": {
+                    "sample_group_id": {"required": True},
+                    "note": {"required": True},
+                },
+                "foreign_keys": [{"entity": "sample_group", "required": True}],
+            },
+        }
+    )
+    project: ShapeShiftProject = load_project("sead_sample_group_note_context.yml")
+
+    assert issue_pairs(target_model, project) == []
+
+
 def test_core_conformance_keeps_alias_like_names_strict() -> None:
     target_model: TargetModel = load_target_model()
     project = ShapeShiftProject(

--- a/tests/model/test_target_model_conformance.py
+++ b/tests/model/test_target_model_conformance.py
@@ -423,7 +423,7 @@ def test_core_conformance_current_corpus_issue_families_are_stable() -> None:
             }
         ),
         "arbodat_full": Counter(
-            {"MISSING_REQUIRED_FOREIGN_KEY_TARGET": 4, "MISSING_REQUIRED_COLUMN": 2, "MISSING_INDUCED_REQUIRED_ENTITY": 1}
+            {"MISSING_REQUIRED_FOREIGN_KEY_TARGET": 3, "MISSING_REQUIRED_COLUMN": 2, "MISSING_INDUCED_REQUIRED_ENTITY": 1}
         ),
     }
 

--- a/tests/model/test_target_model_conformance.py
+++ b/tests/model/test_target_model_conformance.py
@@ -261,6 +261,33 @@ def test_core_conformance_reports_missing_entity_and_wrong_public_id() -> None:
     assert ("UNEXPECTED_PUBLIC_ID", "sample") in issues
 
 
+def test_core_conformance_accepts_sample_note_example_fixture() -> None:
+    target_model: TargetModel = _minimal_target_model(
+        {
+            "sample": {
+                "required": True,
+                "public_id": "physical_sample_id",
+                "columns": {
+                    "sample_name": {"required": True},
+                },
+            },
+            "sample_note": {
+                "required": False,
+                "public_id": "sample_note_id",
+                "columns": {
+                    "physical_sample_id": {"required": True},
+                    "note_type": {"required": False},
+                    "note": {"required": True},
+                },
+                "foreign_keys": [{"entity": "sample", "required": True}],
+            },
+        }
+    )
+    project: ShapeShiftProject = load_project("sead_sample_note_context.yml")
+
+    assert issue_pairs(target_model, project) == []
+
+
 def test_core_conformance_keeps_alias_like_names_strict() -> None:
     target_model: TargetModel = load_target_model()
     project = ShapeShiftProject(

--- a/tests/target_model/test_spec_files.py
+++ b/tests/target_model/test_spec_files.py
@@ -47,6 +47,7 @@ def test_sead_superset_spec_loads_and_validates() -> None:
     analysis_dating_range = target_model.entities["analysis_dating_range"]
     analysis_taxon_count = target_model.entities["analysis_taxon_count"]
     analysis_value_dimension = target_model.entities["analysis_value_dimension"]
+    feature_property = target_model.entities["feature_property"]
     horizon = target_model.entities["horizon"]
     property_type = target_model.entities["property_type"]
     value_class = target_model.entities["value_class"]
@@ -69,7 +70,7 @@ def test_sead_superset_spec_loads_and_validates() -> None:
     sample_horizon = target_model.entities["sample_horizon"]
 
     assert target_model.model.name == "SEAD Clearinghouse Extended"
-    assert len(target_model.entities) == 81
+    assert len(target_model.entities) == 82
     assert {
         "analysis_value",
         "analysis_boolean_value",
@@ -87,6 +88,7 @@ def test_sead_superset_spec_loads_and_validates() -> None:
         "value_type",
         "value_type_item",
         "property_type",
+        "feature_property",
         "site_property",
         "site_natgridref",
     }.issubset(target_model.entities)
@@ -124,6 +126,9 @@ def test_sead_superset_spec_loads_and_validates() -> None:
     assert any(foreign_key.entity == "taxa_tree_master" for foreign_key in analysis_taxon_count.foreign_keys)
     assert analysis_value_dimension.target_table == "tbl_analysis_value_dimensions"
     assert any(foreign_key.entity == "dimension" for foreign_key in analysis_value_dimension.foreign_keys)
+    assert feature_property.target_table == "tbl_feature_properties"
+    assert feature_property.aggregate_parent == "feature"
+    assert any(foreign_key.entity == "property_type" for foreign_key in feature_property.foreign_keys)
     assert property_type.target_table == "tbl_property_types"
     assert any(foreign_key.entity == "value_type" for foreign_key in property_type.foreign_keys)
     assert any(foreign_key.entity == "value_class" for foreign_key in property_type.foreign_keys)

--- a/tests/target_model/test_spec_files.py
+++ b/tests/target_model/test_spec_files.py
@@ -34,6 +34,12 @@ def test_sead_superset_spec_loads_and_validates() -> None:
     target_model = TargetModel.model_validate(yaml.safe_load(spec_path.read_text(encoding="utf-8")))
 
     issues = TargetModelSpecValidator().validate(target_model)
+    analysis_value = target_model.entities["analysis_value"]
+    analysis_note = target_model.entities["analysis_note"]
+    analysis_identifier = target_model.entities["analysis_identifier"]
+    analysis_integer_value = target_model.entities["analysis_integer_value"]
+    analysis_numerical_value = target_model.entities["analysis_numerical_value"]
+    analysis_dating_range = target_model.entities["analysis_dating_range"]
     value_qualifier = target_model.entities["value_qualifier"]
     value_qualifier_symbol = target_model.entities["value_qualifier_symbol"]
     sample_group_coordinate = target_model.entities["sample_group_coordinate"]
@@ -47,12 +53,32 @@ def test_sead_superset_spec_loads_and_validates() -> None:
     sample_horizon = target_model.entities["sample_horizon"]
 
     assert target_model.model.name == "SEAD Clearinghouse Extended"
-    assert len(target_model.entities) == 61
+    assert len(target_model.entities) == 67
+    assert {
+        "analysis_value",
+        "analysis_note",
+        "analysis_identifier",
+        "analysis_integer_value",
+        "analysis_numerical_value",
+        "analysis_dating_range",
+    }.issubset(target_model.entities)
     assert {"sample_horizon", "sample_location", "sample_location_type", "sample_note"}.issubset(target_model.entities)
     assert {"value_qualifier", "value_qualifier_symbol"}.issubset(target_model.entities)
     assert {"sample_group_coordinate", "sample_group_dimension", "sample_group_note", "sample_group_reference"}.issubset(
         target_model.entities
     )
+    assert analysis_value.target_table == "tbl_analysis_values"
+    assert analysis_value.aggregate_parent == "analysis_entity"
+    assert analysis_note.target_table == "tbl_analysis_notes"
+    assert analysis_note.aggregate_parent == "analysis_value"
+    assert analysis_identifier.target_table == "tbl_analysis_identifiers"
+    assert analysis_identifier.aggregate_parent == "analysis_value"
+    assert analysis_integer_value.target_table == "tbl_analysis_integer_values"
+    assert any(foreign_key.entity == "value_qualifier_symbol" for foreign_key in analysis_integer_value.foreign_keys)
+    assert analysis_numerical_value.target_table == "tbl_analysis_numerical_values"
+    assert any(foreign_key.entity == "value_qualifier_symbol" for foreign_key in analysis_numerical_value.foreign_keys)
+    assert analysis_dating_range.target_table == "tbl_analysis_dating_ranges"
+    assert any(foreign_key.entity == "value_qualifier_symbol" for foreign_key in analysis_dating_range.foreign_keys)
     assert value_qualifier.target_table == "tbl_value_qualifiers"
     assert value_qualifier_symbol.target_table == "tbl_value_qualifier_symbols"
     assert any(foreign_key.entity == "value_qualifier" for foreign_key in value_qualifier_symbol.foreign_keys)

--- a/tests/target_model/test_spec_files.py
+++ b/tests/target_model/test_spec_files.py
@@ -34,9 +34,21 @@ def test_sead_superset_spec_loads_and_validates() -> None:
     target_model = TargetModel.model_validate(yaml.safe_load(spec_path.read_text(encoding="utf-8")))
 
     issues = TargetModelSpecValidator().validate(target_model)
+    sample_location_type = target_model.entities["sample_location_type"]
+    sample_location = target_model.entities["sample_location"]
+    sample_note = target_model.entities["sample_note"]
+    sample_horizon = target_model.entities["sample_horizon"]
 
     assert target_model.model.name == "SEAD Clearinghouse Extended"
-    assert len(target_model.entities) == 51
+    assert len(target_model.entities) == 55
+    assert {"sample_horizon", "sample_location", "sample_location_type", "sample_note"}.issubset(target_model.entities)
+    assert sample_location_type.target_table == "tbl_sample_location_types"
+    assert sample_location.target_table == "tbl_sample_locations"
+    assert sample_location.aggregate_parent == "sample"
+    assert sample_note.target_table == "tbl_sample_notes"
+    assert sample_note.aggregate_parent == "sample"
+    assert sample_horizon.target_table == "tbl_sample_horizons"
+    assert sample_horizon.aggregate_parent == "sample"
     assert issues == []
 
 

--- a/tests/target_model/test_spec_files.py
+++ b/tests/target_model/test_spec_files.py
@@ -34,14 +34,30 @@ def test_sead_superset_spec_loads_and_validates() -> None:
     target_model = TargetModel.model_validate(yaml.safe_load(spec_path.read_text(encoding="utf-8")))
 
     issues = TargetModelSpecValidator().validate(target_model)
+    sample_group_coordinate = target_model.entities["sample_group_coordinate"]
+    sample_group_dimension = target_model.entities["sample_group_dimension"]
+    sample_group_note = target_model.entities["sample_group_note"]
+    sample_group_reference = target_model.entities["sample_group_reference"]
     sample_location_type = target_model.entities["sample_location_type"]
     sample_location = target_model.entities["sample_location"]
     sample_note = target_model.entities["sample_note"]
     sample_horizon = target_model.entities["sample_horizon"]
 
     assert target_model.model.name == "SEAD Clearinghouse Extended"
-    assert len(target_model.entities) == 55
+    assert len(target_model.entities) == 59
     assert {"sample_horizon", "sample_location", "sample_location_type", "sample_note"}.issubset(target_model.entities)
+    assert {"sample_group_coordinate", "sample_group_dimension", "sample_group_note", "sample_group_reference"}.issubset(
+        target_model.entities
+    )
+    assert sample_group_coordinate.target_table == "tbl_sample_group_coordinates"
+    assert sample_group_coordinate.public_id == "sample_group_position_id"
+    assert sample_group_coordinate.aggregate_parent == "sample_group"
+    assert sample_group_dimension.target_table == "tbl_sample_group_dimensions"
+    assert sample_group_dimension.aggregate_parent == "sample_group"
+    assert sample_group_note.target_table == "tbl_sample_group_notes"
+    assert sample_group_note.aggregate_parent == "sample_group"
+    assert sample_group_reference.target_table == "tbl_sample_group_references"
+    assert sample_group_reference.aggregate_parent == "sample_group"
     assert sample_location_type.target_table == "tbl_sample_location_types"
     assert sample_location.target_table == "tbl_sample_locations"
     assert sample_location.aggregate_parent == "sample"

--- a/tests/target_model/test_spec_files.py
+++ b/tests/target_model/test_spec_files.py
@@ -29,6 +29,17 @@ def test_sead_v2_spec_loads_and_validates() -> None:
     assert issues == []
 
 
+def test_sead_superset_spec_loads_and_validates() -> None:
+    spec_path = Path("resources/target_models/sead_superset_model.yml")
+    target_model = TargetModel.model_validate(yaml.safe_load(spec_path.read_text(encoding="utf-8")))
+
+    issues = TargetModelSpecValidator().validate(target_model)
+
+    assert target_model.model.name == "SEAD Clearinghouse Extended"
+    assert len(target_model.entities) == 51
+    assert issues == []
+
+
 def test_non_sead_target_model_expresses_cleanly() -> None:
     """Acceptance criterion #5: at least one non-SEAD model can be expressed without schema changes.
 

--- a/tests/target_model/test_spec_files.py
+++ b/tests/target_model/test_spec_files.py
@@ -64,13 +64,24 @@ def test_sead_superset_spec_loads_and_validates() -> None:
     site_natgridref = target_model.entities["site_natgridref"]
     site_property = target_model.entities["site_property"]
     sample_dimension = target_model.entities["sample_dimension"]
+    coordinate_system = target_model.entities["coordinate_system"]
+    colour = target_model.entities["colour"]
+    sample_colour = target_model.entities["sample_colour"]
+    project = target_model.entities["project"]
+    project_type = target_model.entities["project_type"]
+    project_stage = target_model.entities["project_stage"]
+    taxa_synonyms = target_model.entities["taxa_synonyms"]
+    taxa_measured_attributes = target_model.entities["taxa_measured_attributes"]
+    rdb_system = target_model.entities["rdb_system"]
+    rdb_code = target_model.entities["rdb_code"]
+    rdb = target_model.entities["rdb"]
     sample_location_type = target_model.entities["sample_location_type"]
     sample_location = target_model.entities["sample_location"]
     sample_note = target_model.entities["sample_note"]
     sample_horizon = target_model.entities["sample_horizon"]
 
     assert target_model.model.name == "SEAD Clearinghouse Extended"
-    assert len(target_model.entities) == 82
+    assert len(target_model.entities) == 92
     assert {
         "analysis_value",
         "analysis_boolean_value",
@@ -92,7 +103,25 @@ def test_sead_superset_spec_loads_and_validates() -> None:
         "site_property",
         "site_natgridref",
     }.issubset(target_model.entities)
-    assert {"sample_horizon", "sample_location", "sample_location_type", "sample_note", "horizon"}.issubset(target_model.entities)
+    assert {
+        "sample_horizon",
+        "sample_location",
+        "sample_location_type",
+        "sample_note",
+        "horizon",
+        "coordinate_system",
+        "colour",
+        "sample_colour",
+        "project_type",
+        "project_stage",
+        "taxa_synonyms",
+        "taxa_measured_attributes",
+        "rdb_system",
+        "rdb_code",
+        "rdb",
+    }.issubset(
+        target_model.entities
+    )
     assert {"value_qualifier", "value_qualifier_symbol"}.issubset(target_model.entities)
     assert {"sample_group_coordinate", "sample_group_dimension", "sample_group_note", "sample_group_reference", "sample_group_sampling_context"}.issubset(
         target_model.entities
@@ -138,6 +167,30 @@ def test_sead_superset_spec_loads_and_validates() -> None:
     assert value_qualifier.target_table == "tbl_value_qualifiers"
     assert value_qualifier_symbol.target_table == "tbl_value_qualifier_symbols"
     assert any(foreign_key.entity == "value_qualifier" for foreign_key in value_qualifier_symbol.foreign_keys)
+    assert colour.target_table == "tbl_colours"
+    assert any(foreign_key.entity == "method" for foreign_key in colour.foreign_keys)
+    assert sample_colour.target_table == "tbl_sample_colours"
+    assert sample_colour.aggregate_parent == "sample"
+    assert any(foreign_key.entity == "colour" for foreign_key in sample_colour.foreign_keys)
+    assert coordinate_system.target_table == "tbl_coordinate_systems"
+    assert project_type.target_table == "tbl_project_types"
+    assert project_stage.target_table == "tbl_project_stages"
+    assert any(foreign_key.entity == "project_type" for foreign_key in project.foreign_keys)
+    assert any(foreign_key.entity == "project_stage" for foreign_key in project.foreign_keys)
+    assert taxa_synonyms.target_table == "tbl_taxa_synonyms"
+    assert taxa_synonyms.aggregate_parent == "taxa_tree_master"
+    assert any(foreign_key.entity == "citation" for foreign_key in taxa_synonyms.foreign_keys)
+    assert taxa_measured_attributes.target_table == "tbl_taxa_measured_attributes"
+    assert taxa_measured_attributes.aggregate_parent == "taxa_tree_master"
+    assert any(foreign_key.entity == "taxa_tree_master" for foreign_key in taxa_measured_attributes.foreign_keys)
+    assert rdb_system.target_table == "tbl_rdb_systems"
+    assert any(foreign_key.entity == "location" for foreign_key in rdb_system.foreign_keys)
+    assert any(foreign_key.entity == "citation" for foreign_key in rdb_system.foreign_keys)
+    assert rdb_code.target_table == "tbl_rdb_codes"
+    assert any(foreign_key.entity == "rdb_system" for foreign_key in rdb_code.foreign_keys)
+    assert rdb.target_table == "tbl_rdb"
+    assert rdb.aggregate_parent == "taxa_tree_master"
+    assert any(foreign_key.entity == "rdb_code" for foreign_key in rdb.foreign_keys)
     assert value_type.target_table == "tbl_value_types"
     assert any(foreign_key.entity == "unit" for foreign_key in value_type.foreign_keys)
     assert value_type_item.target_table == "tbl_value_type_items"

--- a/tests/target_model/test_spec_files.py
+++ b/tests/target_model/test_spec_files.py
@@ -34,30 +34,39 @@ def test_sead_superset_spec_loads_and_validates() -> None:
     target_model = TargetModel.model_validate(yaml.safe_load(spec_path.read_text(encoding="utf-8")))
 
     issues = TargetModelSpecValidator().validate(target_model)
+    value_qualifier = target_model.entities["value_qualifier"]
+    value_qualifier_symbol = target_model.entities["value_qualifier_symbol"]
     sample_group_coordinate = target_model.entities["sample_group_coordinate"]
     sample_group_dimension = target_model.entities["sample_group_dimension"]
     sample_group_note = target_model.entities["sample_group_note"]
     sample_group_reference = target_model.entities["sample_group_reference"]
+    sample_dimension = target_model.entities["sample_dimension"]
     sample_location_type = target_model.entities["sample_location_type"]
     sample_location = target_model.entities["sample_location"]
     sample_note = target_model.entities["sample_note"]
     sample_horizon = target_model.entities["sample_horizon"]
 
     assert target_model.model.name == "SEAD Clearinghouse Extended"
-    assert len(target_model.entities) == 59
+    assert len(target_model.entities) == 61
     assert {"sample_horizon", "sample_location", "sample_location_type", "sample_note"}.issubset(target_model.entities)
+    assert {"value_qualifier", "value_qualifier_symbol"}.issubset(target_model.entities)
     assert {"sample_group_coordinate", "sample_group_dimension", "sample_group_note", "sample_group_reference"}.issubset(
         target_model.entities
     )
+    assert value_qualifier.target_table == "tbl_value_qualifiers"
+    assert value_qualifier_symbol.target_table == "tbl_value_qualifier_symbols"
+    assert any(foreign_key.entity == "value_qualifier" for foreign_key in value_qualifier_symbol.foreign_keys)
     assert sample_group_coordinate.target_table == "tbl_sample_group_coordinates"
     assert sample_group_coordinate.public_id == "sample_group_position_id"
     assert sample_group_coordinate.aggregate_parent == "sample_group"
     assert sample_group_dimension.target_table == "tbl_sample_group_dimensions"
     assert sample_group_dimension.aggregate_parent == "sample_group"
+    assert any(foreign_key.entity == "value_qualifier" for foreign_key in sample_group_dimension.foreign_keys)
     assert sample_group_note.target_table == "tbl_sample_group_notes"
     assert sample_group_note.aggregate_parent == "sample_group"
     assert sample_group_reference.target_table == "tbl_sample_group_references"
     assert sample_group_reference.aggregate_parent == "sample_group"
+    assert any(foreign_key.entity == "value_qualifier" for foreign_key in sample_dimension.foreign_keys)
     assert sample_location_type.target_table == "tbl_sample_location_types"
     assert sample_location.target_table == "tbl_sample_locations"
     assert sample_location.aggregate_parent == "sample"

--- a/tests/target_model/test_spec_files.py
+++ b/tests/target_model/test_spec_files.py
@@ -34,19 +34,24 @@ def test_sead_superset_spec_loads_and_validates() -> None:
     target_model = TargetModel.model_validate(yaml.safe_load(spec_path.read_text(encoding="utf-8")))
 
     issues = TargetModelSpecValidator().validate(target_model)
+    analysis_categorical_value = target_model.entities["analysis_categorical_value"]
     analysis_value = target_model.entities["analysis_value"]
     analysis_boolean_value = target_model.entities["analysis_boolean_value"]
     analysis_note = target_model.entities["analysis_note"]
     analysis_identifier = target_model.entities["analysis_identifier"]
     analysis_integer_range = target_model.entities["analysis_integer_range"]
     analysis_integer_value = target_model.entities["analysis_integer_value"]
+    analysis_numerical_range = target_model.entities["analysis_numerical_range"]
     analysis_numerical_value = target_model.entities["analysis_numerical_value"]
     analysis_dating_range = target_model.entities["analysis_dating_range"]
     analysis_taxon_count = target_model.entities["analysis_taxon_count"]
     analysis_value_dimension = target_model.entities["analysis_value_dimension"]
     horizon = target_model.entities["horizon"]
+    value_class = target_model.entities["value_class"]
     value_qualifier = target_model.entities["value_qualifier"]
     value_qualifier_symbol = target_model.entities["value_qualifier_symbol"]
+    value_type = target_model.entities["value_type"]
+    value_type_item = target_model.entities["value_type_item"]
     sample_group = target_model.entities["sample_group"]
     sample_group_coordinate = target_model.entities["sample_group_coordinate"]
     sample_group_dimension = target_model.entities["sample_group_dimension"]
@@ -60,18 +65,23 @@ def test_sead_superset_spec_loads_and_validates() -> None:
     sample_horizon = target_model.entities["sample_horizon"]
 
     assert target_model.model.name == "SEAD Clearinghouse Extended"
-    assert len(target_model.entities) == 73
+    assert len(target_model.entities) == 78
     assert {
         "analysis_value",
         "analysis_boolean_value",
+        "analysis_categorical_value",
         "analysis_note",
         "analysis_identifier",
         "analysis_integer_range",
         "analysis_integer_value",
+        "analysis_numerical_range",
         "analysis_numerical_value",
         "analysis_dating_range",
         "analysis_taxon_count",
         "analysis_value_dimension",
+        "value_class",
+        "value_type",
+        "value_type_item",
     }.issubset(target_model.entities)
     assert {"sample_horizon", "sample_location", "sample_location_type", "sample_note", "horizon"}.issubset(target_model.entities)
     assert {"value_qualifier", "value_qualifier_symbol"}.issubset(target_model.entities)
@@ -80,8 +90,12 @@ def test_sead_superset_spec_loads_and_validates() -> None:
     )
     assert analysis_value.target_table == "tbl_analysis_values"
     assert analysis_value.aggregate_parent == "analysis_entity"
+    assert analysis_value.columns["value_class_id"].nullable is False
+    assert any(foreign_key.entity == "value_class" for foreign_key in analysis_value.foreign_keys)
     assert analysis_boolean_value.target_table == "tbl_analysis_boolean_values"
     assert analysis_boolean_value.aggregate_parent == "analysis_value"
+    assert analysis_categorical_value.target_table == "tbl_analysis_categorical_values"
+    assert any(foreign_key.entity == "value_type_item" for foreign_key in analysis_categorical_value.foreign_keys)
     assert analysis_note.target_table == "tbl_analysis_notes"
     assert analysis_note.aggregate_parent == "analysis_value"
     assert analysis_identifier.target_table == "tbl_analysis_identifiers"
@@ -90,6 +104,9 @@ def test_sead_superset_spec_loads_and_validates() -> None:
     assert any(foreign_key.entity == "value_qualifier_symbol" for foreign_key in analysis_integer_range.foreign_keys)
     assert analysis_integer_value.target_table == "tbl_analysis_integer_values"
     assert any(foreign_key.entity == "value_qualifier_symbol" for foreign_key in analysis_integer_value.foreign_keys)
+    assert analysis_numerical_range.target_table == "tbl_analysis_numerical_ranges"
+    assert analysis_numerical_range.columns["value"].type == "numrange"
+    assert any(foreign_key.entity == "value_qualifier_symbol" for foreign_key in analysis_numerical_range.foreign_keys)
     assert analysis_numerical_value.target_table == "tbl_analysis_numerical_values"
     assert any(foreign_key.entity == "value_qualifier_symbol" for foreign_key in analysis_numerical_value.foreign_keys)
     assert analysis_dating_range.target_table == "tbl_analysis_dating_ranges"
@@ -98,9 +115,16 @@ def test_sead_superset_spec_loads_and_validates() -> None:
     assert any(foreign_key.entity == "taxa_tree_master" for foreign_key in analysis_taxon_count.foreign_keys)
     assert analysis_value_dimension.target_table == "tbl_analysis_value_dimensions"
     assert any(foreign_key.entity == "dimension" for foreign_key in analysis_value_dimension.foreign_keys)
+    assert value_class.target_table == "tbl_value_classes"
+    assert any(foreign_key.entity == "value_type" for foreign_key in value_class.foreign_keys)
+    assert any(foreign_key.entity == "method" for foreign_key in value_class.foreign_keys)
     assert value_qualifier.target_table == "tbl_value_qualifiers"
     assert value_qualifier_symbol.target_table == "tbl_value_qualifier_symbols"
     assert any(foreign_key.entity == "value_qualifier" for foreign_key in value_qualifier_symbol.foreign_keys)
+    assert value_type.target_table == "tbl_value_types"
+    assert any(foreign_key.entity == "unit" for foreign_key in value_type.foreign_keys)
+    assert value_type_item.target_table == "tbl_value_type_items"
+    assert any(foreign_key.entity == "value_type" for foreign_key in value_type_item.foreign_keys)
     assert sample_group.target_table == "tbl_sample_groups"
     assert any(foreign_key.entity == "sample_group_sampling_context" for foreign_key in sample_group.foreign_keys)
     assert sample_group_coordinate.target_table == "tbl_sample_group_coordinates"

--- a/tests/target_model/test_spec_files.py
+++ b/tests/target_model/test_spec_files.py
@@ -35,17 +35,24 @@ def test_sead_superset_spec_loads_and_validates() -> None:
 
     issues = TargetModelSpecValidator().validate(target_model)
     analysis_value = target_model.entities["analysis_value"]
+    analysis_boolean_value = target_model.entities["analysis_boolean_value"]
     analysis_note = target_model.entities["analysis_note"]
     analysis_identifier = target_model.entities["analysis_identifier"]
+    analysis_integer_range = target_model.entities["analysis_integer_range"]
     analysis_integer_value = target_model.entities["analysis_integer_value"]
     analysis_numerical_value = target_model.entities["analysis_numerical_value"]
     analysis_dating_range = target_model.entities["analysis_dating_range"]
+    analysis_taxon_count = target_model.entities["analysis_taxon_count"]
+    analysis_value_dimension = target_model.entities["analysis_value_dimension"]
+    horizon = target_model.entities["horizon"]
     value_qualifier = target_model.entities["value_qualifier"]
     value_qualifier_symbol = target_model.entities["value_qualifier_symbol"]
+    sample_group = target_model.entities["sample_group"]
     sample_group_coordinate = target_model.entities["sample_group_coordinate"]
     sample_group_dimension = target_model.entities["sample_group_dimension"]
     sample_group_note = target_model.entities["sample_group_note"]
     sample_group_reference = target_model.entities["sample_group_reference"]
+    sample_group_sampling_context = target_model.entities["sample_group_sampling_context"]
     sample_dimension = target_model.entities["sample_dimension"]
     sample_location_type = target_model.entities["sample_location_type"]
     sample_location = target_model.entities["sample_location"]
@@ -53,35 +60,49 @@ def test_sead_superset_spec_loads_and_validates() -> None:
     sample_horizon = target_model.entities["sample_horizon"]
 
     assert target_model.model.name == "SEAD Clearinghouse Extended"
-    assert len(target_model.entities) == 67
+    assert len(target_model.entities) == 73
     assert {
         "analysis_value",
+        "analysis_boolean_value",
         "analysis_note",
         "analysis_identifier",
+        "analysis_integer_range",
         "analysis_integer_value",
         "analysis_numerical_value",
         "analysis_dating_range",
+        "analysis_taxon_count",
+        "analysis_value_dimension",
     }.issubset(target_model.entities)
-    assert {"sample_horizon", "sample_location", "sample_location_type", "sample_note"}.issubset(target_model.entities)
+    assert {"sample_horizon", "sample_location", "sample_location_type", "sample_note", "horizon"}.issubset(target_model.entities)
     assert {"value_qualifier", "value_qualifier_symbol"}.issubset(target_model.entities)
-    assert {"sample_group_coordinate", "sample_group_dimension", "sample_group_note", "sample_group_reference"}.issubset(
+    assert {"sample_group_coordinate", "sample_group_dimension", "sample_group_note", "sample_group_reference", "sample_group_sampling_context"}.issubset(
         target_model.entities
     )
     assert analysis_value.target_table == "tbl_analysis_values"
     assert analysis_value.aggregate_parent == "analysis_entity"
+    assert analysis_boolean_value.target_table == "tbl_analysis_boolean_values"
+    assert analysis_boolean_value.aggregate_parent == "analysis_value"
     assert analysis_note.target_table == "tbl_analysis_notes"
     assert analysis_note.aggregate_parent == "analysis_value"
     assert analysis_identifier.target_table == "tbl_analysis_identifiers"
     assert analysis_identifier.aggregate_parent == "analysis_value"
+    assert analysis_integer_range.target_table == "tbl_analysis_integer_ranges"
+    assert any(foreign_key.entity == "value_qualifier_symbol" for foreign_key in analysis_integer_range.foreign_keys)
     assert analysis_integer_value.target_table == "tbl_analysis_integer_values"
     assert any(foreign_key.entity == "value_qualifier_symbol" for foreign_key in analysis_integer_value.foreign_keys)
     assert analysis_numerical_value.target_table == "tbl_analysis_numerical_values"
     assert any(foreign_key.entity == "value_qualifier_symbol" for foreign_key in analysis_numerical_value.foreign_keys)
     assert analysis_dating_range.target_table == "tbl_analysis_dating_ranges"
     assert any(foreign_key.entity == "value_qualifier_symbol" for foreign_key in analysis_dating_range.foreign_keys)
+    assert analysis_taxon_count.target_table == "tbl_analysis_taxon_counts"
+    assert any(foreign_key.entity == "taxa_tree_master" for foreign_key in analysis_taxon_count.foreign_keys)
+    assert analysis_value_dimension.target_table == "tbl_analysis_value_dimensions"
+    assert any(foreign_key.entity == "dimension" for foreign_key in analysis_value_dimension.foreign_keys)
     assert value_qualifier.target_table == "tbl_value_qualifiers"
     assert value_qualifier_symbol.target_table == "tbl_value_qualifier_symbols"
     assert any(foreign_key.entity == "value_qualifier" for foreign_key in value_qualifier_symbol.foreign_keys)
+    assert sample_group.target_table == "tbl_sample_groups"
+    assert any(foreign_key.entity == "sample_group_sampling_context" for foreign_key in sample_group.foreign_keys)
     assert sample_group_coordinate.target_table == "tbl_sample_group_coordinates"
     assert sample_group_coordinate.public_id == "sample_group_position_id"
     assert sample_group_coordinate.aggregate_parent == "sample_group"
@@ -92,14 +113,18 @@ def test_sead_superset_spec_loads_and_validates() -> None:
     assert sample_group_note.aggregate_parent == "sample_group"
     assert sample_group_reference.target_table == "tbl_sample_group_references"
     assert sample_group_reference.aggregate_parent == "sample_group"
+    assert sample_group_sampling_context.target_table == "tbl_sample_group_sampling_contexts"
     assert any(foreign_key.entity == "value_qualifier" for foreign_key in sample_dimension.foreign_keys)
     assert sample_location_type.target_table == "tbl_sample_location_types"
     assert sample_location.target_table == "tbl_sample_locations"
     assert sample_location.aggregate_parent == "sample"
     assert sample_note.target_table == "tbl_sample_notes"
     assert sample_note.aggregate_parent == "sample"
+    assert horizon.target_table == "tbl_horizons"
+    assert any(foreign_key.entity == "method" for foreign_key in horizon.foreign_keys)
     assert sample_horizon.target_table == "tbl_sample_horizons"
     assert sample_horizon.aggregate_parent == "sample"
+    assert any(foreign_key.entity == "horizon" for foreign_key in sample_horizon.foreign_keys)
     assert issues == []
 
 

--- a/tests/target_model/test_spec_files.py
+++ b/tests/target_model/test_spec_files.py
@@ -37,6 +37,7 @@ def test_sead_superset_spec_loads_and_validates() -> None:
     analysis_categorical_value = target_model.entities["analysis_categorical_value"]
     analysis_value = target_model.entities["analysis_value"]
     analysis_boolean_value = target_model.entities["analysis_boolean_value"]
+    abundance_property = target_model.entities["abundance_property"]
     analysis_note = target_model.entities["analysis_note"]
     analysis_identifier = target_model.entities["analysis_identifier"]
     analysis_integer_range = target_model.entities["analysis_integer_range"]
@@ -47,6 +48,7 @@ def test_sead_superset_spec_loads_and_validates() -> None:
     analysis_taxon_count = target_model.entities["analysis_taxon_count"]
     analysis_value_dimension = target_model.entities["analysis_value_dimension"]
     horizon = target_model.entities["horizon"]
+    property_type = target_model.entities["property_type"]
     value_class = target_model.entities["value_class"]
     value_qualifier = target_model.entities["value_qualifier"]
     value_qualifier_symbol = target_model.entities["value_qualifier_symbol"]
@@ -58,6 +60,8 @@ def test_sead_superset_spec_loads_and_validates() -> None:
     sample_group_note = target_model.entities["sample_group_note"]
     sample_group_reference = target_model.entities["sample_group_reference"]
     sample_group_sampling_context = target_model.entities["sample_group_sampling_context"]
+    site_natgridref = target_model.entities["site_natgridref"]
+    site_property = target_model.entities["site_property"]
     sample_dimension = target_model.entities["sample_dimension"]
     sample_location_type = target_model.entities["sample_location_type"]
     sample_location = target_model.entities["sample_location"]
@@ -65,7 +69,7 @@ def test_sead_superset_spec_loads_and_validates() -> None:
     sample_horizon = target_model.entities["sample_horizon"]
 
     assert target_model.model.name == "SEAD Clearinghouse Extended"
-    assert len(target_model.entities) == 78
+    assert len(target_model.entities) == 81
     assert {
         "analysis_value",
         "analysis_boolean_value",
@@ -82,6 +86,9 @@ def test_sead_superset_spec_loads_and_validates() -> None:
         "value_class",
         "value_type",
         "value_type_item",
+        "property_type",
+        "site_property",
+        "site_natgridref",
     }.issubset(target_model.entities)
     assert {"sample_horizon", "sample_location", "sample_location_type", "sample_note", "horizon"}.issubset(target_model.entities)
     assert {"value_qualifier", "value_qualifier_symbol"}.issubset(target_model.entities)
@@ -111,10 +118,15 @@ def test_sead_superset_spec_loads_and_validates() -> None:
     assert any(foreign_key.entity == "value_qualifier_symbol" for foreign_key in analysis_numerical_value.foreign_keys)
     assert analysis_dating_range.target_table == "tbl_analysis_dating_ranges"
     assert any(foreign_key.entity == "value_qualifier_symbol" for foreign_key in analysis_dating_range.foreign_keys)
+    assert abundance_property.target_table == "tbl_abundance_properties"
+    assert any(foreign_key.entity == "property_type" for foreign_key in abundance_property.foreign_keys)
     assert analysis_taxon_count.target_table == "tbl_analysis_taxon_counts"
     assert any(foreign_key.entity == "taxa_tree_master" for foreign_key in analysis_taxon_count.foreign_keys)
     assert analysis_value_dimension.target_table == "tbl_analysis_value_dimensions"
     assert any(foreign_key.entity == "dimension" for foreign_key in analysis_value_dimension.foreign_keys)
+    assert property_type.target_table == "tbl_property_types"
+    assert any(foreign_key.entity == "value_type" for foreign_key in property_type.foreign_keys)
+    assert any(foreign_key.entity == "value_class" for foreign_key in property_type.foreign_keys)
     assert value_class.target_table == "tbl_value_classes"
     assert any(foreign_key.entity == "value_type" for foreign_key in value_class.foreign_keys)
     assert any(foreign_key.entity == "method" for foreign_key in value_class.foreign_keys)
@@ -138,6 +150,12 @@ def test_sead_superset_spec_loads_and_validates() -> None:
     assert sample_group_reference.target_table == "tbl_sample_group_references"
     assert sample_group_reference.aggregate_parent == "sample_group"
     assert sample_group_sampling_context.target_table == "tbl_sample_group_sampling_contexts"
+    assert site_property.target_table == "tbl_site_properties"
+    assert site_property.aggregate_parent == "site"
+    assert any(foreign_key.entity == "property_type" for foreign_key in site_property.foreign_keys)
+    assert site_natgridref.target_table == "tbl_site_natgridrefs"
+    assert site_natgridref.aggregate_parent == "site"
+    assert any(foreign_key.entity == "method" for foreign_key in site_natgridref.foreign_keys)
     assert any(foreign_key.entity == "value_qualifier" for foreign_key in sample_dimension.foreign_keys)
     assert sample_location_type.target_table == "tbl_sample_location_types"
     assert sample_location.target_table == "tbl_sample_locations"

--- a/tests/target_model/test_spec_validator.py
+++ b/tests/target_model/test_spec_validator.py
@@ -1,5 +1,90 @@
+import pytest
+from pydantic import ValidationError
+
 from src.target_model.models import TargetModel
 from src.target_model.spec_validator import TargetModelSpecValidator
+
+
+@pytest.mark.parametrize(
+    ("raw", "loc"),
+    [
+        (
+            {
+                "model": {
+                    "name": "SEAD Clearinghouse",
+                    "version": "2.0.0",
+                    "unexpected": True,
+                },
+                "entities": {},
+            },
+            ("model", "unexpected"),
+        ),
+        (
+            {
+                "model": {
+                    "name": "SEAD Clearinghouse",
+                    "version": "2.0.0",
+                },
+                "entities": {
+                    "site": {
+                        "public_id": "site_id",
+                        "unexpected": True,
+                    }
+                },
+            },
+            ("entities", "site", "unexpected"),
+        ),
+        (
+            {
+                "model": {
+                    "name": "SEAD Clearinghouse",
+                    "version": "2.0.0",
+                },
+                "entities": {
+                    "location": {
+                        "public_id": "location_id",
+                    },
+                    "site": {
+                        "public_id": "site_id",
+                        "foreign_keys": [
+                            {
+                                "entity": "location",
+                                "unexpected": True,
+                            }
+                        ],
+                    },
+                },
+            },
+            ("entities", "site", "foreign_keys", 0, "unexpected"),
+        ),
+        (
+            {
+                "model": {
+                    "name": "SEAD Clearinghouse",
+                    "version": "2.0.0",
+                },
+                "entities": {
+                    "site": {
+                        "public_id": "site_id",
+                        "columns": {
+                            "site_name": {
+                                "required": True,
+                                "unexpected": True,
+                            }
+                        },
+                    }
+                },
+            },
+            ("entities", "site", "columns", "site_name", "unexpected"),
+        ),
+    ],
+)
+def test_target_model_rejects_unknown_keys(raw: dict, loc: tuple[object, ...]) -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        TargetModel.model_validate(raw)
+
+    assert exc_info.value.errors()[0]["type"] == "extra_forbidden"
+    assert exc_info.value.errors()[0]["loc"] == loc
 
 
 def test_validator_reports_unknown_foreign_key_entity() -> None:
@@ -72,3 +157,88 @@ def test_validator_reports_unknown_identity_and_unique_set_columns() -> None:
     issues = TargetModelSpecValidator().validate(target_model)
 
     assert [issue.code for issue in issues] == ["UNKNOWN_IDENTITY_COLUMN", "UNKNOWN_UNIQUE_SET_COLUMN"]
+
+
+def test_validator_reports_aggregate_parent_semantic_issues() -> None:
+    target_model = TargetModel.model_validate(
+        {
+            "model": {
+                "name": "SEAD Clearinghouse",
+                "version": "2.0.0",
+            },
+            "entities": {
+                "sample": {
+                    "role": "fact",
+                    "public_id": "sample_id",
+                },
+                "sample_description": {
+                    "role": "fact",
+                    "public_id": "sample_description_id",
+                    "aggregate_parent": "sample",
+                    "identity_tracking": "tracked",
+                    "foreign_keys": [],
+                },
+                "sample_note": {
+                    "role": "fact",
+                    "public_id": "sample_note_id",
+                    "identity_tracking": "child",
+                },
+                "orphan_child": {
+                    "role": "fact",
+                    "public_id": "orphan_child_id",
+                    "aggregate_parent": "missing_parent",
+                },
+                "recursive_child": {
+                    "role": "fact",
+                    "public_id": "recursive_child_id",
+                    "aggregate_parent": "recursive_child",
+                },
+            },
+        }
+    )
+
+    issues = TargetModelSpecValidator().validate(target_model)
+
+    assert [(issue.code, issue.entity) for issue in issues] == [
+        ("AGGREGATE_PARENT_CONFLICTS_WITH_IDENTITY_TRACKING", "sample_description"),
+        ("MISSING_AGGREGATE_PARENT_FOREIGN_KEY", "sample_description"),
+        ("CHILD_IDENTITY_MISSING_AGGREGATE_PARENT", "sample_note"),
+        ("UNKNOWN_AGGREGATE_PARENT", "orphan_child"),
+        ("SELF_REFERENTIAL_AGGREGATE_PARENT", "recursive_child"),
+    ]
+
+
+def test_validator_reports_invalid_identity_reconciliation_combinations() -> None:
+    target_model = TargetModel.model_validate(
+        {
+            "model": {
+                "name": "SEAD Clearinghouse",
+                "version": "2.0.0",
+            },
+            "entities": {
+                "tracked_entity": {
+                    "role": "fact",
+                    "public_id": "tracked_entity_id",
+                    "reconciliation": "lookup-only",
+                },
+                "derived_entity": {
+                    "role": "bridge",
+                    "public_id": "derived_entity_id",
+                    "reconciliation": "allocate",
+                },
+                "ambiguous_lookup": {
+                    "role": "fact",
+                    "public_id": "ambiguous_lookup_id",
+                    "identity_tracking": "reconciled",
+                },
+            },
+        }
+    )
+
+    issues = TargetModelSpecValidator().validate(target_model)
+
+    assert [(issue.code, issue.entity) for issue in issues] == [
+        ("INVALID_IDENTITY_RECONCILIATION_COMBINATION", "tracked_entity"),
+        ("INVALID_IDENTITY_RECONCILIATION_COMBINATION", "derived_entity"),
+        ("INVALID_IDENTITY_RECONCILIATION_COMBINATION", "ambiguous_lookup"),
+    ]

--- a/tests/test_data/examples/sead_sample_group_note_context.yml
+++ b/tests/test_data/examples/sead_sample_group_note_context.yml
@@ -1,0 +1,28 @@
+metadata:
+  name: example:sead-sample-group-note-context
+  type: shapeshifter-project
+  description: Minimal SEAD-shaped project fixture covering the sample_group_note entity.
+  version: 1.0.0
+
+entities:
+  sample_group:
+    type: entity
+    public_id: sample_group_id
+    keys: []
+    columns: []
+    extra_columns:
+      sample_group_name:
+
+  sample_group_note:
+    type: entity
+    public_id: sample_group_note_id
+    keys: []
+    columns: []
+    foreign_keys:
+      - entity: sample_group
+        local_keys: [sample_group_id]
+        remote_keys: [sample_group_id]
+    extra_columns:
+      note:
+
+options: {}

--- a/tests/test_data/examples/sead_sample_note_context.yml
+++ b/tests/test_data/examples/sead_sample_note_context.yml
@@ -1,0 +1,29 @@
+metadata:
+  name: example:sead-sample-note-context
+  type: shapeshifter-project
+  description: Minimal SEAD-shaped project fixture covering the sample_note entity.
+  version: 1.0.0
+
+entities:
+  sample:
+    type: entity
+    public_id: physical_sample_id
+    keys: []
+    columns: []
+    extra_columns:
+      sample_name:
+
+  sample_note:
+    type: entity
+    public_id: sample_note_id
+    keys: []
+    columns: []
+    foreign_keys:
+      - entity: sample
+        local_keys: [physical_sample_id]
+        remote_keys: [physical_sample_id]
+    extra_columns:
+      note_type:
+      note:
+
+options: {}


### PR DESCRIPTION
Problem

The shared SEAD superset still had multiple open target-model follow-up slices across sample context, sample-group context, property patterns, analysis values, shared lookup families, and deferred lookup reassessment.

Solution

Complete the branch tranche that adds the remaining shared-model entities and lookup families, updates validation and conformance expectations, and aligns the proposals with the implemented branch state.

This branch:
- adds sample-context and sample-group context entities
- adds property-pattern and site context entities
- adds analysis-value entities and value qualifier lookups
- resolves deferred lookup candidates by promoting shared lookups such as colour, project classification, coordinate_system, taxonomy/RDB entities, and by keeping abundance properties on shared property_type
- keeps dating_period and natural_region out of the shared superset as Arbodat-specific
- updates target-model docs and focused tests to match the current superset

Files

- resources/target_models/sead_superset_model.yml
- tests/target_model/test_spec_files.py
- tests/model/test_target_model_conformance.py
- docs/TARGET_MODEL_GUIDE.md
- docs/proposals/SEAD_V2_TARGET_MODEL_COMPLETENESS.md
- docs/proposals/SEAD_V2_TARGET_MODEL_FOLLOWUP_ISSUES.md

Validation

- uv run pytest tests/target_model/test_spec_files.py tests/target_model/test_spec_validator.py tests/model/test_target_model_conformance.py backend/tests/validators/test_target_model_validator.py -q

Fixes #447
Fixes #448
Fixes #449
Fixes #450
Fixes #451
Fixes #452
Fixes #453
