### PR TITLE
feat(target-model): finish conformance backlog rollout

### DIFF
--- a/backend/app/api/v1/endpoints/validation.py
+++ b/backend/app/api/v1/endpoints/validation.py
@@ -96,7 +96,7 @@ async def validate_target_model(name: str) -> ValidationResult:
         name: Project name
 
     Returns:
-        Validation result with conformance errors (severity="error").
+        Validation result with conformance issues grouped by severity.
         ``is_valid`` is True when there are zero conformance issues.
     """
     validation_service: ValidationService = get_validation_service()

--- a/backend/app/mappers/validation_mapper.py
+++ b/backend/app/mappers/validation_mapper.py
@@ -97,7 +97,7 @@ class ValidationMapper:
         Convert a core ConformanceIssue to an API ValidationError.
 
         Conformance issues are structural by category and high priority by default.
-        Severity is always 'error' — conformance violations are hard requirements.
+        Severity is preserved from the core conformance issue.
 
         Args:
             issue: Core conformance issue from TargetModelConformanceValidator

--- a/backend/app/services/validation_service.py
+++ b/backend/app/services/validation_service.py
@@ -250,7 +250,7 @@ class ValidationService:
             project_name: Project name to validate.
 
         Returns:
-            ValidationResult with conformance errors (severity="error") only.
+            ValidationResult with conformance issues grouped by severity.
             is_valid is True only when there are zero conformance errors.
         """
         from backend.app.validators.target_model_validator import TargetModelValidator  # pylint: disable=import-outside-toplevel
@@ -273,9 +273,13 @@ class ValidationService:
             return ValidationResult(is_valid=True)
 
         logger.debug(f"Running target-model conformance for project: {project_name}")
-        errors: list[ValidationError] = TargetModelValidator().validate(target_model_data, core_project)
+        issues: list[ValidationError] = TargetModelValidator().validate(target_model_data, core_project)
 
-        return ValidationResult(is_valid=len(errors) == 0, errors=errors)
+        errors: list[ValidationError] = [issue for issue in issues if issue.severity == "error"]
+        warnings: list[ValidationError] = [issue for issue in issues if issue.severity == "warning"]
+        info: list[ValidationError] = [issue for issue in issues if issue.severity == "info"]
+
+        return ValidationResult(is_valid=len(errors) == 0, errors=errors, warnings=warnings, info=info)
 
 
 # Singleton instance

--- a/backend/app/validators/data_validation_orchestrator.py
+++ b/backend/app/validators/data_validation_orchestrator.py
@@ -20,6 +20,7 @@ from src.model import ShapeShiftProject
 from src.normalizer import ShapeShifter
 from src.table_store import TableStore
 from src.target_model.data_validators import (
+    AllowedValuesConformanceValidator,
     FKReferentialIntegrityConformanceValidator,
     NullabilityConformanceValidator,
     TypeCompatibilityConformanceValidator,
@@ -239,6 +240,7 @@ class DataValidationOrchestrator:
                 if entity_spec is not None:
                     issues.extend(NullabilityConformanceValidator.validate(df, entity_spec, entity_name))
                     issues.extend(TypeCompatibilityConformanceValidator.validate(df, entity_spec, entity_name))
+                    issues.extend(AllowedValuesConformanceValidator.validate(df, entity_spec, entity_name))
 
                     for fk_spec in entity_spec.foreign_keys:
                         if not fk_spec.required or fk_spec.via:

--- a/backend/tests/mappers/test_project_mapper_file_path_integration.py
+++ b/backend/tests/mappers/test_project_mapper_file_path_integration.py
@@ -125,6 +125,65 @@ class TestProjectMapperFilePathIntegration:
             expected_path = str(mock_settings.global_data_dir / "global_data.csv")
             assert entity_options["filename"] == expected_path
 
+    def test_to_core_resolves_project_local_target_model_include(self, mock_settings: Settings) -> None:
+        """Test that to_core() resolves a project-local target model include to a dict."""
+        with patch("backend.app.mappers.project_mapper.settings", mock_settings):
+            project_dir = mock_settings.projects_root / "test_project"
+            project_file = project_dir / "shapeshifter.yml"
+            project_file.write_text("metadata:\n  name: test_project\nentities: {}\n", encoding="utf-8")
+            target_model_path = project_dir / "target-model.yml"
+            target_model_path.write_text(
+                "model:\n  name: Test Model\n  format_version: '1'\n  version: '1.0.0'\nentities: {}\n",
+                encoding="utf-8",
+            )
+
+            api_project = Project(
+                metadata=ProjectMetadata(
+                    name="test_project",
+                    file_path=str(project_file),
+                    type="shapeshifter-project",
+                    description="Test project",
+                    version="1.0.0",
+                    entity_count=0,
+                    target_model="@include: target-model.yml",
+                ),
+                entities={},
+                options={},
+            )
+
+            core_project = ProjectMapper.to_core(api_project)
+
+            assert isinstance(core_project.metadata.target_model, dict)
+            assert core_project.metadata.target_model["model"] == {
+                "name": "Test Model",
+                "format_version": "1",
+                "version": "1.0.0",
+            }
+            assert core_project.metadata.target_model["entities"] == {}
+
+    def test_to_core_raises_file_not_found_for_missing_target_model_include(self, mock_settings: Settings) -> None:
+        """Test that to_core() raises a clear FileNotFoundError for missing target model includes."""
+        with patch("backend.app.mappers.project_mapper.settings", mock_settings):
+            project_dir = mock_settings.projects_root / "test_project"
+            project_file = project_dir / "shapeshifter.yml"
+            project_file.write_text("metadata:\n  name: test_project\nentities: {}\n", encoding="utf-8")
+            api_project = Project(
+                metadata=ProjectMetadata(
+                    name="test_project",
+                    file_path=str(project_file),
+                    type="shapeshifter-project",
+                    description="Test project",
+                    version="1.0.0",
+                    entity_count=0,
+                    target_model="@include: missing-target-model.yml",
+                ),
+                entities={},
+                options={},
+            )
+
+            with pytest.raises(FileNotFoundError, match="missing-target-model.yml"):
+                ProjectMapper.to_core(api_project)
+
     def test_to_api_config_restores_location_for_global_file(self, mock_settings: Settings) -> None:
         """Test that to_api_config() decomposes absolute paths back to location + filename."""
         with patch("backend.app.mappers.project_mapper.settings", mock_settings):

--- a/backend/tests/services/test_validation_service.py
+++ b/backend/tests/services/test_validation_service.py
@@ -454,6 +454,40 @@ class TestDataValidation:
 class TestValidateTargetModel:
     """Tests for validate_target_model error-handling path."""
 
+    def test_projects_without_target_model_return_empty_valid_result(self, validation_service: ValidationService):
+        """Projects without a target model should skip conformance cleanly."""
+        mock_api_project = Mock(spec=Project)
+        mock_core_project = Mock()
+        mock_core_project.metadata.target_model = None
+
+        with patch("backend.app.services.validation_service.get_project_service") as mock_get_service:
+            mock_project_service = Mock()
+            mock_project_service.load_project.return_value = mock_api_project
+            mock_get_service.return_value = mock_project_service
+
+            with patch("backend.app.services.validation_service.ProjectMapper.to_core", return_value=mock_core_project):
+                result = validation_service.validate_target_model("test-project")
+
+        assert result.is_valid is True
+        assert result.errors == []
+
+    def test_target_model_null_is_treated_as_missing(self, validation_service: ValidationService):
+        """A resolved null target_model should behave the same as an absent target model."""
+        mock_api_project = Mock(spec=Project)
+        mock_core_project = Mock()
+        mock_core_project.metadata.target_model = None
+
+        with patch("backend.app.services.validation_service.get_project_service") as mock_get_service:
+            mock_project_service = Mock()
+            mock_project_service.load_project.return_value = mock_api_project
+            mock_get_service.return_value = mock_project_service
+
+            with patch("backend.app.services.validation_service.ProjectMapper.to_core", return_value=mock_core_project):
+                result = validation_service.validate_target_model("test-project")
+
+        assert result.is_valid is True
+        assert result.errors == []
+
     def test_missing_target_model_file_is_silently_ignored(self, validation_service: ValidationService):
         """FileNotFoundError from @include resolution must be silently ignored (valid=True, no errors)."""
         mock_api_project = Mock(spec=Project)

--- a/backend/tests/services/test_validation_service.py
+++ b/backend/tests/services/test_validation_service.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from backend.app.models.validation import ValidationCategory, ValidationPriority
 from backend.app.mappers.project_mapper import ProjectMapper
 from backend.app.models.project import Project, ProjectMetadata
 from backend.app.services import validation_service as validation_service_module
@@ -505,3 +506,37 @@ class TestValidateTargetModel:
 
         assert result.is_valid is True
         assert result.errors == []
+
+    def test_target_model_validation_groups_warnings_by_severity(self, validation_service: ValidationService):
+        """Target-model validation should keep conformance warnings out of the error bucket."""
+        mock_api_project = Mock(spec=Project)
+        mock_core_project = Mock()
+        mock_core_project.metadata.target_model = {"model": {"name": "Test Model", "version": "1.0.0"}, "entities": {}}
+
+        with patch("backend.app.services.validation_service.get_project_service") as mock_get_service:
+            mock_project_service = Mock()
+            mock_project_service.load_project.return_value = mock_api_project
+            mock_get_service.return_value = mock_project_service
+
+            with patch("backend.app.services.validation_service.ProjectMapper.to_core", return_value=mock_core_project):
+                with patch("backend.app.validators.target_model_validator.TargetModelValidator") as mock_validator_cls:
+                    mock_validator = Mock()
+                    mock_validator.validate.return_value = [
+                        validation_service_module.ValidationError(
+                            severity="warning",
+                            entity="analysis_entity",
+                            field=None,
+                            message="Warning",
+                            code="ORPHAN_FACT_ENTITY",
+                            category=ValidationCategory.CONFORMANCE,
+                            priority=ValidationPriority.HIGH,
+                            auto_fixable=False,
+                        )
+                    ]
+                    mock_validator_cls.return_value = mock_validator
+
+                    result = validation_service.validate_target_model("test-project")
+
+        assert result.is_valid is True
+        assert result.errors == []
+        assert [warning.code for warning in result.warnings] == ["ORPHAN_FACT_ENTITY"]

--- a/backend/tests/validators/test_target_model_validator.py
+++ b/backend/tests/validators/test_target_model_validator.py
@@ -165,6 +165,25 @@ class TestTargetModelValidatorErrorPaths:
 
         assert any(e.code == "MISSING_REQUIRED_COLUMN" for e in errors)
 
+    def test_generated_required_column_does_not_return_missing_required_column(self):
+        """Required generated columns should not produce missing-column conformance errors."""
+        project = _make_project({"location": _minimal_entity(public_id="location_id", columns=["location_name"])})
+        target_model_data = _minimal_target_model(
+            entities={
+                "location": {
+                    "public_id": "location_id",
+                    "columns": {
+                        "location_name": {"required": True},
+                        "location_slug": {"required": True, "generated": True},
+                    },
+                }
+            }
+        )
+
+        errors = TargetModelValidator().validate(target_model_data, project)
+
+        assert all(e.code != "MISSING_REQUIRED_COLUMN" for e in errors)
+
     def test_unknown_foreign_key_entity_returns_specific_spec_issue(self):
         """Spec self-consistency issues should surface their specific code, not INVALID_TARGET_MODEL."""
         project = _make_project({})

--- a/backend/tests/validators/test_target_model_validator.py
+++ b/backend/tests/validators/test_target_model_validator.py
@@ -9,11 +9,12 @@ from src.model import ShapeShiftProject
 # ---------------------------------------------------------------------------
 
 
-def _make_project(entities: dict) -> ShapeShiftProject:
+def _make_project(entities: dict, options: dict | None = None) -> ShapeShiftProject:
     """Build a minimal resolved ShapeShiftProject with the given entity configs."""
     cfg: dict = {
         "metadata": {"name": "test-project", "type": "shapeshifter-project"},
         "entities": entities,
+        "options": options or {},
     }
     return ShapeShiftProject(cfg=cfg, filename="test.yml")
 
@@ -169,6 +170,16 @@ class TestTargetModelValidatorErrorPaths:
 
         assert [error.code for error in errors] == ["MISSING_AGGREGATE_PARENT_FOREIGN_KEY"]
         assert errors[0].entity == "sample_description"
+
+    def test_unknown_disabled_rule_returns_warning(self):
+        """Unknown disabled rule keys should surface as warnings instead of being silently ignored."""
+        project = _make_project({}, options={"validation": {"disabled_rules": ["not_a_real_rule"]}})
+
+        errors = TargetModelValidator().validate(_minimal_target_model(), project)
+
+        assert [error.code for error in errors] == ["UNKNOWN_DISABLED_CONFORMANCE_RULE"]
+        assert errors[0].severity == "warning"
+        assert errors[0].field == "options.validation.disabled_rules"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/validators/test_target_model_validator.py
+++ b/backend/tests/validators/test_target_model_validator.py
@@ -69,6 +69,37 @@ class TestTargetModelValidatorHappyPaths:
 
         assert errors == []
 
+    def test_transitive_foreign_key_path_returns_no_errors(self):
+        """A required FK satisfied through an intermediate project entity should not raise a direct-FK error."""
+        project = _make_project(
+            {
+                "site": {"public_id": "site_id", "columns": ["site_name"]},
+                "sample_group": {
+                    "public_id": "sample_group_id",
+                    "columns": ["sample_group_name"],
+                    "foreign_keys": [{"entity": "site", "local_keys": ["site_id"], "remote_keys": ["site_id"]}],
+                },
+                "sample": {
+                    "public_id": "sample_id",
+                    "columns": ["sample_name"],
+                    "foreign_keys": [
+                        {"entity": "sample_group", "local_keys": ["sample_group_id"], "remote_keys": ["sample_group_id"]}
+                    ],
+                },
+            }
+        )
+        target_model_data = _minimal_target_model(
+            entities={
+                "site": {"required": True, "public_id": "site_id"},
+                "sample_group": {"required": True, "public_id": "sample_group_id", "foreign_keys": [{"entity": "site", "required": True}]},
+                "sample": {"required": True, "public_id": "sample_id", "foreign_keys": [{"entity": "site", "required": True}]},
+            }
+        )
+
+        errors = TargetModelValidator().validate(target_model_data, project)
+
+        assert errors == []
+
 
 # ---------------------------------------------------------------------------
 # TargetModelValidator.validate – error paths

--- a/backend/tests/validators/test_target_model_validator.py
+++ b/backend/tests/validators/test_target_model_validator.py
@@ -233,6 +233,31 @@ class TestTargetModelValidatorErrorPaths:
 
         assert any(error.code == "ORPHAN_FACT_ENTITY" for error in errors)
 
+    def test_schema_aware_append_returns_missing_required_column_error(self):
+        """Append branches missing required target columns should surface through the adapter."""
+        project = _make_project(
+            {
+                "site": {
+                    "public_id": "site_id",
+                    "columns": ["site_name", "site_type"],
+                    "append": [{"type": "fixed", "columns": ["site_name"], "values": [["Append Site"]]}],
+                }
+            }
+        )
+        target_model_data = _minimal_target_model(
+            entities={
+                "site": {
+                    "required": True,
+                    "public_id": "site_id",
+                    "columns": {"site_name": {"required": True}, "site_type": {"required": True}},
+                }
+            }
+        )
+
+        errors = TargetModelValidator().validate(target_model_data, project)
+
+        assert any(error.code == "APPEND_MISSING_REQUIRED_COLUMN" for error in errors)
+
 
 # ---------------------------------------------------------------------------
 # ValidationError shape produced by the adapter

--- a/backend/tests/validators/test_target_model_validator.py
+++ b/backend/tests/validators/test_target_model_validator.py
@@ -231,8 +231,28 @@ class TestTargetModelValidatorErrorPaths:
         assert errors[0].severity == "warning"
         assert errors[0].field == "options.validation.disabled_rules"
 
-    def test_orphan_fact_constraint_returns_error(self):
-        """Declared orphan-fact constraints should surface as conformance errors through the adapter."""
+    def test_unknown_severity_override_returns_warning(self):
+        """Unknown severity override keys should surface as warnings instead of being silently ignored."""
+        project = _make_project({}, options={"validation": {"severity_overrides": {"not_a_real_rule": "warning"}}})
+
+        errors = TargetModelValidator().validate(_minimal_target_model(), project)
+
+        assert [error.code for error in errors] == ["UNKNOWN_CONFORMANCE_SEVERITY_OVERRIDE"]
+        assert errors[0].severity == "warning"
+        assert errors[0].field == "options.validation.severity_overrides"
+
+    def test_invalid_severity_override_returns_warning(self):
+        """Invalid severity override values should surface as warnings instead of being silently ignored."""
+        project = _make_project({}, options={"validation": {"severity_overrides": {"required_entity": "fatal"}}})
+
+        errors = TargetModelValidator().validate(_minimal_target_model(), project)
+
+        assert [error.code for error in errors] == ["INVALID_CONFORMANCE_SEVERITY_OVERRIDE"]
+        assert errors[0].severity == "warning"
+        assert errors[0].field == "options.validation.severity_overrides.required_entity"
+
+    def test_orphan_fact_constraint_returns_warning_by_default(self):
+        """Declared orphan-fact constraints should surface as conformance warnings unless marked strict."""
         project = _make_project(
             {
                 "analysis_entity": {"public_id": "analysis_entity_id", "columns": ["analysis_name"]},
@@ -250,7 +270,48 @@ class TestTargetModelValidatorErrorPaths:
 
         errors = TargetModelValidator().validate(target_model_data, project)
 
-        assert any(error.code == "ORPHAN_FACT_ENTITY" for error in errors)
+        orphan_fact_error = next(error for error in errors if error.code == "ORPHAN_FACT_ENTITY")
+        assert orphan_fact_error.severity == "warning"
+
+    def test_orphan_fact_constraint_returns_error_when_strict(self):
+        """Strict orphan-fact constraints should surface as conformance errors through the adapter."""
+        project = _make_project(
+            {
+                "analysis_entity": {"public_id": "analysis_entity_id", "columns": ["analysis_name"]},
+                "dataset": {"public_id": "dataset_id", "columns": ["dataset_name"]},
+            }
+        )
+        target_model_data = {
+            "model": {"name": "Test Model", "version": "1.0.0"},
+            "constraints": [{"type": "no_orphan_facts", "required": "strict"}],
+            "entities": {
+                "dataset": {"role": "lookup", "required": True, "public_id": "dataset_id"},
+                "analysis_entity": {"role": "fact", "required": True, "public_id": "analysis_entity_id"},
+            },
+        }
+
+        errors = TargetModelValidator().validate(target_model_data, project)
+
+        orphan_fact_error = next(error for error in errors if error.code == "ORPHAN_FACT_ENTITY")
+        assert orphan_fact_error.severity == "error"
+
+    def test_source_type_appropriateness_returns_warning_by_default(self):
+        """Classifier source-type mismatches should surface as warnings through the adapter."""
+        project = _make_project(
+            {
+                "taxon": {"type": "entity", "public_id": "taxon_id", "columns": ["taxon_name"]},
+            }
+        )
+        target_model_data = _minimal_target_model(
+            entities={
+                "taxon": {"role": "classifier", "required": True, "public_id": "taxon_id"},
+            }
+        )
+
+        errors = TargetModelValidator().validate(target_model_data, project)
+
+        source_type_error = next(error for error in errors if error.code == "CLASSIFIER_WRONG_SOURCE_TYPE")
+        assert source_type_error.severity == "warning"
 
     def test_schema_aware_append_returns_missing_required_column_error(self):
         """Append branches missing required target columns should surface through the adapter."""

--- a/backend/tests/validators/test_target_model_validator.py
+++ b/backend/tests/validators/test_target_model_validator.py
@@ -212,6 +212,27 @@ class TestTargetModelValidatorErrorPaths:
         assert errors[0].severity == "warning"
         assert errors[0].field == "options.validation.disabled_rules"
 
+    def test_orphan_fact_constraint_returns_error(self):
+        """Declared orphan-fact constraints should surface as conformance errors through the adapter."""
+        project = _make_project(
+            {
+                "analysis_entity": {"public_id": "analysis_entity_id", "columns": ["analysis_name"]},
+                "dataset": {"public_id": "dataset_id", "columns": ["dataset_name"]},
+            }
+        )
+        target_model_data = {
+            "model": {"name": "Test Model", "version": "1.0.0"},
+            "constraints": [{"type": "no_orphan_facts"}],
+            "entities": {
+                "dataset": {"role": "lookup", "required": True, "public_id": "dataset_id"},
+                "analysis_entity": {"role": "fact", "required": True, "public_id": "analysis_entity_id"},
+            },
+        }
+
+        errors = TargetModelValidator().validate(target_model_data, project)
+
+        assert any(error.code == "ORPHAN_FACT_ENTITY" for error in errors)
+
 
 # ---------------------------------------------------------------------------
 # ValidationError shape produced by the adapter

--- a/docs/README.md
+++ b/docs/README.md
@@ -127,8 +127,8 @@ Current proposals:
 - **[proposals/QUERY_FILTER_ENGINE_SELECTION.md](proposals/QUERY_FILTER_ENGINE_SELECTION.md)**
   - Proposes adding an explicit `engine` field to `type: query` filters for advanced pandas query behavior.
 
-- **[proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md)**
-  - Tracks the remaining deferred target-model conformance work after the completed core milestones.
+- **[proposals/done/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](proposals/done/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md)**
+  - Records the completed conformance backlog rollout and the deferred follow-up that moved out of the active proposal set.
 
 - **[proposals/CHANGE_REQUEST_INGESTER/](proposals/CHANGE_REQUEST_INGESTER/)**
   - Groups the active change-request ingester design and follow-up proposal documents.

--- a/docs/TARGET_MODEL_GUIDE.md
+++ b/docs/TARGET_MODEL_GUIDE.md
@@ -475,4 +475,4 @@ Output files are written to `docs/generated/` by default. Run `python scripts/ge
 - [CONFIGURATION_GUIDE.md](CONFIGURATION_GUIDE.md) — full project YAML reference, including the `metadata.target_model` field
 - [TARGET_MODEL_SCHEMA_REFERENCE.md](TARGET_MODEL_SCHEMA_REFERENCE.md) — generated field-by-field schema reference derived from the Pydantic models
 - [USER_GUIDE.md](USER_GUIDE.md) — editor UI guide, including the Check Conformance button and Conformance panel
-- [docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md) — deferred and future work backlog
+- [docs/proposals/done/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](proposals/done/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md) — closed consolidation record for the delivered conformance backlog and deferred follow-up

--- a/docs/TARGET_MODEL_GUIDE.md
+++ b/docs/TARGET_MODEL_GUIDE.md
@@ -290,7 +290,7 @@ constraints:
 
 Current constraints are modeled as simple typed entries. Add new constraint-specific keys only after extending the Pydantic schema.
 
-Global constraints are planned for future validation phases. `no_orphan_facts` is declared in the SEAD spec but not yet enforced by the conformance engine. It records the intended rule that every fact entity must be reachable from at least one required lookup.
+`no_orphan_facts` is now enforced by the conformance engine when the target model declares it. The rule checks that each fact entity present in the project reaches at least one lookup or classifier through the target-facing FK graph.
 
 ---
 

--- a/docs/TARGET_MODEL_SCHEMA_REFERENCE.md
+++ b/docs/TARGET_MODEL_SCHEMA_REFERENCE.md
@@ -25,6 +25,7 @@ Unknown keys in these sections are rejected because each model uses `extra="forb
 - `entities.<entity_name>.columns`: map[string, ColumnSpec] (optional)
 - `entities.<entity_name>.columns.<column_name>`: ColumnSpec (map value)
 - `entities.<entity_name>.columns.<column_name>.required`: boolean (optional)
+- `entities.<entity_name>.columns.<column_name>.generated`: boolean (optional)
 - `entities.<entity_name>.columns.<column_name>.type`: string | null (optional)
 - `entities.<entity_name>.columns.<column_name>.nullable`: boolean | null (optional)
 - `entities.<entity_name>.columns.<column_name>.description`: string | null (optional)
@@ -98,6 +99,7 @@ Values under `entities.<entity_name>.columns.<column_name>` for each declared co
 | Field | Type | Required | Default | Allowed |
 |---|---|---|---|---|
 | required | boolean | No | false | - |
+| generated | boolean | No | false | - |
 | type | string \| null | No | null | null |
 | nullable | boolean \| null | No | null | null |
 | description | string \| null | No | null | null |

--- a/docs/TARGET_MODEL_SCHEMA_REFERENCE.md
+++ b/docs/TARGET_MODEL_SCHEMA_REFERENCE.md
@@ -45,6 +45,7 @@ Unknown keys in these sections are rejected because each model uses `extra="forb
 - `constraints`: list[GlobalConstraint] (optional)
 - `constraints[]`: GlobalConstraint (list item)
 - `constraints[].type`: string (required)
+- `constraints[].required`: boolean | string | null (optional)
 
 ## TargetModel
 
@@ -138,5 +139,6 @@ Entries under the optional `constraints[]` list.
 | Field | Type | Required | Default | Allowed |
 |---|---|---|---|---|
 | type | string | Yes | - | - |
+| required | boolean \| string \| null | No | null | null |
 
 Additional keys allowed: No

--- a/docs/TARGET_MODEL_SCHEMA_REFERENCE.md
+++ b/docs/TARGET_MODEL_SCHEMA_REFERENCE.md
@@ -63,6 +63,7 @@ Values under the `model` section that identify the specification.
 | Field | Type | Required | Default | Allowed |
 |---|---|---|---|---|
 | name | string | Yes | - | - |
+| format_version | string | No | "1" | - |
 | version | string | Yes | - | - |
 | description | string \| null | No | null | null |
 

--- a/docs/TARGET_MODEL_SCHEMA_REFERENCE.md
+++ b/docs/TARGET_MODEL_SCHEMA_REFERENCE.md
@@ -26,6 +26,8 @@ Unknown keys in these sections are rejected because each model uses `extra="forb
 - `entities.<entity_name>.columns.<column_name>`: ColumnSpec (map value)
 - `entities.<entity_name>.columns.<column_name>.required`: boolean (optional)
 - `entities.<entity_name>.columns.<column_name>.generated`: boolean (optional)
+- `entities.<entity_name>.columns.<column_name>.allowed_values`: list[string | integer | number | boolean] (optional)
+- `entities.<entity_name>.columns.<column_name>.allowed_values[]`: string | integer | number | boolean (list item)
 - `entities.<entity_name>.columns.<column_name>.type`: string | null (optional)
 - `entities.<entity_name>.columns.<column_name>.nullable`: boolean | null (optional)
 - `entities.<entity_name>.columns.<column_name>.description`: string | null (optional)
@@ -100,6 +102,7 @@ Values under `entities.<entity_name>.columns.<column_name>` for each declared co
 |---|---|---|---|---|
 | required | boolean | No | false | - |
 | generated | boolean | No | false | - |
+| allowed_values | list[string \| integer \| number \| boolean] | No | [] | - |
 | type | string \| null | No | null | null |
 | nullable | boolean \| null | No | null | null |
 | description | string \| null | No | null | null |

--- a/docs/proposals/COMPLEX_ENTITY_MODELING_ERGONOMICS.md
+++ b/docs/proposals/COMPLEX_ENTITY_MODELING_ERGONOMICS.md
@@ -201,7 +201,7 @@ This would make multi-branch parent modeling less error-prone while preserving t
 
 **Status: Completed — see **[done/FIRST_CLASS_MERGED_PARENT_ENTITIES](done/FIRST_CLASS_MERGED_PARENT_ENTITIES.md)**
 
-Conformance validation is implemented and wired into the UX. The final delivered scope covers structural conformance (column presence, naming conventions, FK requirements, induced requirements), standalone target-model checks, and a registry-based conformance validator architecture. Remaining enhancement backlog is tracked in [TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md).
+Conformance validation is implemented and wired into the UX. The final delivered scope covers structural conformance (column presence, naming conventions, FK requirements, induced requirements), standalone target-model checks, and a registry-based conformance validator architecture. The closed follow-through record lives in [done/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](done/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md).
 
 ## Proposal 7: Derived Lookup Helpers
 
@@ -292,7 +292,7 @@ The delivery order below is organized by implementation risk, not only by concep
 - ✔️ FOUNDATION COMPLETE **[Proposal 8: Comment-Preserving Save Path](COMMENT_PRESERVING_SAVE_PATH.md)**
   The boundary-based persistence layer is now in place (see [done/BOUNDARY_BASED_PROJECT_PERSISTENCE.md](done/BOUNDARY_BASED_PROJECT_PERSISTENCE.md)), providing the subtree-merge primitives this feature requires. Full comment-preserving round-trips across the editor are still pending.
 - ✔️ COMPLETED **[Proposal 6: Target-Schema-Aware Validation](done/TARGET_SCHEMA_AWARE_VALIDATION.md)**
-  Conformance validation is implemented and wired into the UX. Remaining backlog (data conformance, branch-aware rules) is tracked in [TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md).
+  Conformance validation is implemented and wired into the UX. Remaining follow-up notes (data conformance, branch-aware rules) are summarized in [done/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](done/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md).
 
 ### Phase 2: Branch-Aware Modeling Helpers
 
@@ -301,7 +301,7 @@ The delivery order below is organized by implementation risk, not only by concep
 - ✔️ FOUNDATION COMPLETE **Proposal 5: Source-Based Append With Alignment** (see [done/SOURCE_BASED_APPEND_WITH_POSITION_ALIGNMENT.md](done/SOURCE_BASED_APPEND_WITH_POSITION_ALIGNMENT.md))
   Source-based append and column alignment modes are now implemented. The higher-level `branches:` entity syntax from the original proposal sketch remains conceptual. Proposal 4 (branch-scoped consumers) is the natural next step now that heterogeneous source appends can be expressed and aligned correctly.
 - ✔️ COMPLETED **[Proposal 6: Target-Schema-Aware Validation](done/TARGET_SCHEMA_AWARE_VALIDATION.md)**
-  Completed in Phase 1. Phase 2 expansion rules (branch-aware conformance) are tracked in [TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md).
+  Completed in Phase 1. Phase 2 expansion rules (branch-aware conformance) are summarized in [done/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](done/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md).
 
 ### Phase 3: First-Class Modeling Constructs
 docs/proposals/done/FIRST_CLASS_MERGED_PARENT_ENTITIES.md

--- a/docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md
+++ b/docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md
@@ -26,7 +26,7 @@
 See [Target-Model-Aware Data Conformance](#target-model-aware-data-conformance) for design rationale and implementation notes.
 
 ### Format Extensions
-- [ ] `format_version` field in `model:` block
+- [x] `format_version` field in `model:` block
 - [ ] `generated: true` flag on `ColumnSpec` (suppress missing-column warnings for auto-generated columns)
 - [ ] `allowed_values` / `type: enum` on `ColumnSpec`
 - [x] Richer FK semantics — bridge entity support via `via` attribute in FK spec
@@ -34,9 +34,9 @@ See [Target-Model-Aware Data Conformance](#target-model-aware-data-conformance) 
 ~~- [ ] Entity spec inheritance (`extends:`) — defer until 5+ target models exist~~
 
 ### Test Coverage
-- [ ] Target model spec parsing — valid and invalid cases are covered; round-trip coverage is still missing
-- [ ] `@include:` resolution at mapper boundary (inline dict, file ref, missing file, relative path)
-- [ ] Projects without target model — structural validation unaffected, conformance returns empty
+- [x] Target model spec parsing — valid and invalid cases are covered; round-trip coverage is still missing
+- [x] `@include:` resolution at mapper boundary (inline dict, file ref, missing file, relative path)
+- [x] Projects without target model — structural validation unaffected, conformance returns empty
 - [x] Missing target model file — graceful handling, treated as no target model rather than a 500
 - [x] Backend adapter integration — `TargetModelValidator` code mapping, endpoint response, category tagging
 - [ ] Warning vs error severity (Phase 4 checks)
@@ -61,7 +61,7 @@ See [Target-Model-Aware Data Conformance](#target-model-aware-data-conformance) 
 - [x] Sample context and sample-group context — `sample_horizon`, `sample_location`, `sample_location_type`, `sample_note`, `sample_group_coordinate`, `sample_group_dimension`, `sample_group_note`, `sample_group_reference`, `sample_group_sampling_context`, `horizon`
 - [x] Analysis-value family and shared lookups — `analysis_value`, `analysis_note`, `analysis_identifier`, typed analysis value entities, `property_type`, `value_class`, `value_type`, `value_type_item`, `value_qualifier`, `value_qualifier_symbol`
 - [x] Property and lookup follow-up coverage — `site_property`, `feature_property`, `site_natgridref`, `coordinate_system`, `colour`, `sample_colour`, `project_type`, `project_stage`, `taxa_synonyms`, `taxa_measured_attributes`, `rdb`, `rdb_code`, `rdb_system`
-- [ ] Taxonomy — `taxa_tree_master`, `taxa_common_names`, `taxa_synonyms`, `taxa_measured_attributes`, `ecocode_system`, `ecocode_group`, `ecocode_definition`, `ecocode`, `rdb`, `rdb_code`, and `rdb_system` are present, but `taxonomic_order` is still missing
+- [x] Taxonomy — `taxa_tree_master`, `taxa_common_names`, `taxa_synonyms`, `taxa_measured_attributes`, `ecocode_system`, `ecocode_group`, `ecocode_definition`, `ecocode`, `taxonomic_order_system`, `taxonomic_order`, `rdb`, `rdb_code`, and `rdb_system`
 ~~- [ ] Data-type-specific tables (ceramics, dendrochronology, insects)~~ — legacy or specialized method-specific tables are not part of the current shared `sead_superset_model.yml` boundary; see [docs/proposals/done/SEAD_V2_TARGET_MODEL_COMPLETENESS.md](done/SEAD_V2_TARGET_MODEL_COMPLETENESS.md)
 
 ---
@@ -330,7 +330,7 @@ The Monaco YAML editor now provides autocomplete and IntelliSense for target mod
 
 **Remaining Work:**
 
-Backend endpoints and frontend save/load wiring are complete. The remaining gap is frontend visibility behavior for shared/global target model references.
+Backend endpoints, save/load wiring, Monaco schema support, and frontend visibility behavior for shared/global target model references are complete.
 
 ### Complexity Assessment
 
@@ -544,7 +544,7 @@ Should target models support `extends:` to share column sets across entity specs
 
 A `format_version` field alongside `model.version` would allow the parser to reject incompatible target model files cleanly.
 
-**Recommendation:** Add `format_version: "1"` to the top-level `model:` block in a minor update. No behavior change in v1 — treat missing as `"1"`. Start enforcing with any breaking format change.
+**Status:** Implemented. `format_version` now lives under `model:` and defaults to `"1"` when omitted, so older target models still parse.
 
 ### Richer Foreign Key Semantics
 
@@ -582,6 +582,8 @@ These test areas were identified in the implementation sketch but not yet covere
 - Parse invalid YAML — missing required `model.name`, unknown `role` value, malformed `columns`
 - Round-trip: parse → serialize → re-parse produces equivalent object
 
+**Status:** Valid payloads, invalid field rejection, and round-trip coverage are now in place.
+
 ### `@include:` Resolution (Backend Boundary)
 
 - Inline `target_model: {...}` dict passes through mapper unchanged
@@ -589,11 +591,15 @@ These test areas were identified in the implementation sketch but not yet covere
 - Missing include file produces a clear error, not a cryptic KeyError
 - Relative path resolution from project file location
 
+**Status:** Covered for project-local include resolution and missing include files.
+
 ### Projects Without Target Model
 
 - Structural validation runs normally when `metadata.target_model` is absent
 - Conformance endpoint returns empty result (not error) when no target model is set
 - Adding `target_model: null` clears the reference cleanly
+
+**Status:** Covered for missing and null resolved target models.
 
 ### Warning vs Error Severity (Phase 4)
 
@@ -734,7 +740,7 @@ Generate human-readable documentation for target models in HTML, Markdown, or Ex
 
 Remaining shared-model SEAD coverage gaps in `resources/target_models/sead_superset_model.yml`:
 
-- Taxonomy-order support (`taxonomic_order` and any supporting order-system entities that belong in the shared superset)
+- No currently identified shared-model gaps in the agreed taxonomy slice.
 
 Out of scope for this backlog:
 
@@ -751,13 +757,10 @@ Out of scope for this backlog:
 
 When resuming work on this backlog, a sensible order is:
 
-1. **Source-type appropriateness** — low complexity, high value, zero false-positives
-2. **`format_version` field** — trivial parser change, prevents future breakage
-3. **Test coverage gaps** — fill the backend adapter and missing-file tests
-4. **Rule disabling** — needed before shipping Phase 4 checks widely
-5. **Semantic mismatch detection** — requires tuning; start with a conservative threshold
-6. **Transitive FK satisfaction** — well-defined algorithm, removes real false-positives
-7. **`no_orphan_facts`** check — depends on FK graph walk being tested first
-8. **Alias matching / normalization** — only after alias table or metric is agreed on
+1. **Rule disabling** — needed before shipping Phase 4 checks widely
+2. **Semantic mismatch detection** — requires tuning; start with a conservative threshold
+3. **Transitive FK satisfaction** — well-defined algorithm, removes real false-positives
+4. **`no_orphan_facts`** check — depends on FK graph walk being tested first
+5. **Alias matching / normalization** — only after alias table or metric is agreed on
 
 Items in the "Future Enhancements" section (remote refs, registry, diff tooling) are speculative — implement only if a concrete need arises.

--- a/docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md
+++ b/docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md
@@ -84,7 +84,7 @@ Seven conformance validators are registered and active:
 |--------------------------------|-------------------------------------------------------------------------------------------|
 | `required_entity`              | Required entities present in the project                                                  |
 | `public_id`                    | `public_id` present and not unexpected                                                    |
-| `foreign_key`                  | Required FK targets present on entities that are in the project (with bridge support)     |
+| `foreign_key`                  | Required FK targets present on entities that are in the project (with bridge and transitive path support) |
 | `required_columns`             | Required columns present                                                                  |
 | `naming_convention`            | `public_id` values end with `naming.public_id_suffix`                                    |
 | `induced_requirements`         | If optional entity X is present and has a required FK to Y, then Y is required (transitively) |
@@ -507,11 +507,13 @@ Some column names include a redundant entity prefix. For example, `sead_method_g
 
 ### Transitive FK Satisfaction
 
-A project may satisfy a required FK transitively through an intermediate entity not named in the target model. The current FK conformance validator only does direct matching.
+A project may satisfy a required FK transitively through an intermediate entity not named in the target model.
 
 **Example:** Target model requires `sample → site`. Project has `sample → sample_group → site`. The requirement is satisfied transitively but would currently fail.
 
-**Approach when ready:** Add a BFS/DFS walk through the project FK graph to find transitive paths to required FK targets.
+**Status:** Implemented. `ForeignKeyConformanceValidator` now walks the project's target-facing FK graph before emitting `MISSING_REQUIRED_FOREIGN_KEY_TARGET`, which removes direct-only false positives such as `sample → sample_group → site`.
+
+**Current limitation:** This is path detection only. The format-level FK modes proposed earlier (`direct`, `transitive`, explicit `path`) are still deferred.
 
 ### Value-Level Checks
 
@@ -754,10 +756,8 @@ Out of scope for this backlog:
 
 When resuming work on this backlog, a sensible order is:
 
-1. **Rule disabling** — needed before shipping Phase 4 checks widely
+1. **`no_orphan_facts`** check — the FK graph walk now exists, so the remaining work is rule design and issue shaping
 2. **Semantic mismatch detection** — requires tuning; start with a conservative threshold
-3. **Transitive FK satisfaction** — well-defined algorithm, removes real false-positives
-4. **`no_orphan_facts`** check — depends on FK graph walk being tested first
-5. **Alias matching / normalization** — only after alias table or metric is agreed on
+3. **Alias matching / normalization** — only after alias table or metric is agreed on
 
 Items in the "Future Enhancements" section (remote refs, registry, diff tooling) are speculative — implement only if a concrete need arises.

--- a/docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md
+++ b/docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md
@@ -15,7 +15,6 @@
 - [x] `induced_requirements` — optional entity present → its required FK targets are induced-required (transitive)
 - [x] `source_type_appropriateness` — classifiers should not use `type: entity`
 - [x] `no_orphan_facts` — fact entities must have a direct or transitive FK path to at least one lookup or classifier when the global constraint is declared
-~~- [ ] `semantic_mismatch` — entity name role disagrees with `public_id` role (Phase 4, high false-positive risk)~~
 - [ ] `schema_aware_append` — appended columns conform to target model column spec
 
 ### Data Conformance Validators
@@ -235,20 +234,6 @@ entity_a:
 ## Advanced Semantic Validation (Phase 4)
 
 These items were labeled "Phase 4 — Advanced Semantic Rules" in the implementation sketch. None are implemented.
-
-### Semantic Mismatch Detection
-
-Detect when an entity's name implies a different semantic role than its `public_id` style.
-
-**Motivating example:** An entity named `relative_dating` (implies a fact) using `public_id: relative_age_id` (implies a lookup). The mismatch is detectable without running the pipeline.
-
-**Approach:**
-- Classify entity names using heuristics (noun patterns, role keywords)
-- Classify `public_id` values using suffix patterns
-- Emit `UNEXPECTED_PUBLIC_ID` or a new `SEMANTIC_ROLE_MISMATCH` code when name-role and id-role disagree
-- Keep detection conservative: only emit for clear, low-noise cases
-
-**Prerequisite:** Define the heuristic threshold before implementing. Avoid false positives at all cost.
 
 ### Global Role-Informed Checks
 
@@ -603,7 +588,6 @@ These test areas were identified in the implementation sketch but not yet covere
 
 ### Warning vs Error Severity (Phase 4)
 
-- Semantic mismatch checks emit warnings, not errors
 - Orphan-fact check is configurable (warning by default, error when `required: strict`)
 - Severity can be overridden via `options.validation.severity_overrides`
 
@@ -757,7 +741,6 @@ Out of scope for this backlog:
 
 When resuming work on this backlog, a sensible order is:
 
-1. **Semantic mismatch detection** — requires tuning; start with a conservative threshold
-2. **Alias matching / normalization** — only after alias table or metric is agreed on
+1. **Alias matching / normalization** — only after alias table or metric is agreed on
 
 Items in the "Future Enhancements" section (remote refs, registry, diff tooling) are speculative — implement only if a concrete need arises.

--- a/docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md
+++ b/docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md
@@ -286,7 +286,7 @@ The project-level YAML view currently shows only the `shapeshifter.yml` file. Wh
 
 **Constraints:**
 - Raw YAML only — no structured form or entity-level UI.
-- Backend read/write access is limited to **project-local files** (i.e. the `@include:` path lives inside the project's own directory). Shared/global spec files (e.g. `resources/target_models/sead_superset_model.yml`) are read-only in this view, and the frontend still needs a tighter visibility check for that case.
+- Backend read/write access is limited to **project-local files** (i.e. the `@include:` path lives inside the project's own directory). Shared/global spec files (e.g. `resources/target_models/sead_superset_model.yml`) are read-only in this view, and the frontend now hides the edit tab for those references.
 - API passes the YAML file content as raw text; the server validates syntax but **never re-serialises** it, so comments and formatting survive the round-trip.
 - Save writes directly to the referenced target model YAML file.
 - Changing the file triggers a re-run of conformance validation (same as editing the project YAML).
@@ -357,7 +357,7 @@ No extra service layer was needed for the current local-file scope.
 
 ---
 
-#### Frontend (Low–Medium) — PARTIALLY COMPLETE
+#### Frontend (Low–Medium) — COMPLETE
 
 **Completed:**
 1. ✅ **Monaco schema integration** — `targetModelSchema.json` generated and wired into Monaco YAML editor with `mode="target-model"`
@@ -367,10 +367,7 @@ No extra service layer was needed for the current local-file scope.
 5. ✅ **API methods** — `getTargetModelYaml(projectName)` and `updateTargetModelYaml(projectName, yaml)` are implemented in `frontend/src/api/projects.ts`
 6. ✅ **Backend integration** — load/save handlers are wired to the target-model YAML endpoints
 
-**Remaining work:**
-1. **Conditional visibility** — refine tab visibility so the target-model tab is hidden for shared/global target model references instead of relying on backend 403 handling.
-
-The core Monaco editing experience with autocomplete and save/load wiring is in place. The main remaining UX gap is tab visibility for non-project-local target models.
+The core Monaco editing experience with autocomplete, save/load wiring, and project-local visibility behavior is in place.
 
 ---
 

--- a/docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md
+++ b/docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md
@@ -27,7 +27,7 @@ See [Target-Model-Aware Data Conformance](#target-model-aware-data-conformance) 
 ### Format Extensions
 - [x] `format_version` field in `model:` block
 - [x] `generated: true` flag on `ColumnSpec` (required generated columns are advisory and do not trigger missing-column conformance errors)
-- [ ] `allowed_values` / `type: enum` on `ColumnSpec`
+- [x] `allowed_values` / `type: enum` on `ColumnSpec`
 - [x] Richer FK semantics — bridge entity support via `via` attribute in FK spec
 - [ ] Advanced FK validation modes — `direct`, `transitive`, explicit path constraints
 ~~- [ ] Entity spec inheritance (`extends:`) — defer until 5+ target models exist~~
@@ -475,7 +475,7 @@ The `ColumnSpec.type` field uses logical types (`integer`, `string`, `boolean`, 
 
 ### Deferred
 
-- `allowed_values` / enum value checks — depends on `allowed_values` field in `ColumnSpec` (not yet in format)
+- `allowed_values` / enum value checks — implemented in the data-validation layer for columns that declare `type: enum` and `allowed_values`
 - Row-count constraints — out of scope (the format deliberately does not express cardinality requirements)
 
 ---
@@ -544,9 +544,7 @@ The current FK spec (`entity`, `required`, `columns`) does not express join-colu
 
 ### Allowed Values / Enum Support
 
-Add `allowed_values` or `type: enum` to `ColumnSpec` for validating classifier content without running the pipeline.
-
-**Prerequisite:** Align with any value-level validation design (see value-level checks above).
+**Implemented:** `ColumnSpec` now supports `allowed_values` and `type: enum`. `TargetModelSpecValidator` enforces that `allowed_values` is paired with `type: enum`, and the data-validation pipeline emits `VALUE_NOT_IN_ALLOWED_SET` when produced values fall outside the declared set.
 
 ### Database Defaults and Generated Values
 

--- a/docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md
+++ b/docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md
@@ -42,7 +42,7 @@ See [Target-Model-Aware Data Conformance](#target-model-aware-data-conformance) 
 - [ ] Warning vs error severity (Phase 4 checks)
 
 ### Infrastructure
-- [ ] Rule disabling via `options.validation.disabled_rules`
+- [x] Rule disabling via `options.validation.disabled_rules`
 - [ ] `GlobalConformanceValidator` base type for multi-entity checks
 - [ ] `TargetModelService` — extract loading/caching when remote refs become real
 - [x] Target model YAML editor tab — raw YAML edit tab for the project's **project-local** target model file alongside the project YAML tab
@@ -645,9 +645,9 @@ Should projects be able to suppress specific conformance rules?
 
 **Proposal:** Via `options.validation.disabled_rules: ["naming_convention", "no_orphan_facts"]` in the project YAML.
 
-**Current state:** No rule suppression exists. The conformance engine runs all registered validators unconditionally.
+**Current state:** Implemented for registered target-model conformance validators. Unknown rule keys produce a warning instead of being silently ignored.
 
-**Recommendation:** Implement when false-positive feedback from real projects accumulates. Design as an allow-list that strips matching validators from the registry copy used for that project.
+**Recommendation:** Keep this limited to registry-key filtering for conformance validators until there is a concrete need for severity overrides or broader validation-rule scoping.
 
 ---
 

--- a/docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md
+++ b/docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md
@@ -14,7 +14,7 @@
 - [x] `naming_convention` — `public_id` values end with configured suffix
 - [x] `induced_requirements` — optional entity present → its required FK targets are induced-required (transitive)
 - [x] `source_type_appropriateness` — classifiers should not use `type: entity`
-- [ ] `no_orphan_facts` — fact entities must have a required FK path to at least one required lookup
+- [x] `no_orphan_facts` — fact entities must have a direct or transitive FK path to at least one lookup or classifier when the global constraint is declared
 ~~- [ ] `semantic_mismatch` — entity name role disagrees with `public_id` role (Phase 4, high false-positive risk)~~
 - [ ] `schema_aware_append` — appended columns conform to target model column spec
 
@@ -78,7 +78,7 @@ This proposal consolidates deferred and future items from:
 
 ## What Is Already Implemented
 
-Seven conformance validators are registered and active:
+Eight conformance validators are registered and active:
 
 | Key                            | What it checks                                                                            |
 |--------------------------------|-------------------------------------------------------------------------------------------|
@@ -89,6 +89,7 @@ Seven conformance validators are registered and active:
 | `naming_convention`            | `public_id` values end with `naming.public_id_suffix`                                    |
 | `induced_requirements`         | If optional entity X is present and has a required FK to Y, then Y is required (transitively) |
 | `source_type_appropriateness`  | Classifiers (`role: classifier`) must use `type: fixed` or `type: sql`, not `type: entity` |
+| `no_orphan_facts`              | Fact entities present in the project must reach at least one lookup or classifier when the target model declares that global constraint |
 
 Backend wiring, frontend Check Conformance button, and Conformance panel in ValidationPanel are all live.
 
@@ -253,9 +254,9 @@ Detect when an entity's name implies a different semantic role than its `public_
 
 Check global modeling requirements that depend on understanding the *combination* of entity roles.
 
-**Candidate rule:** `no_orphan_facts` — a fact entity must be linked (directly or transitively) to at least one required lookup entity. A fact with no FK path to any required parent is likely misconfigured.
+**Implemented rule:** `no_orphan_facts` — when the target model declares `constraints: [{type: no_orphan_facts}]`, each fact entity present in the project must be linked (directly or transitively) to at least one lookup or classifier entity declared in the target model.
 
-**Implementation note:** BFS over the required-FK graph is already implemented in `InducedRequirementConformanceValidator`. A `GlobalConformanceValidator` base type and the `no_orphan_facts` rule can reuse that traversal pattern. The FK graph walk no longer needs `ProcessState` as a prerequisite.
+**Implementation note:** The rule reuses the same target-facing FK graph walk used by transitive foreign-key conformance. It runs only when the global constraint is declared, so target models that do not opt in keep current behavior.
 
 ### Source-Type Appropriateness
 
@@ -756,8 +757,7 @@ Out of scope for this backlog:
 
 When resuming work on this backlog, a sensible order is:
 
-1. **`no_orphan_facts`** check — the FK graph walk now exists, so the remaining work is rule design and issue shaping
-2. **Semantic mismatch detection** — requires tuning; start with a conservative threshold
-3. **Alias matching / normalization** — only after alias table or metric is agreed on
+1. **Semantic mismatch detection** — requires tuning; start with a conservative threshold
+2. **Alias matching / normalization** — only after alias table or metric is agreed on
 
 Items in the "Future Enhancements" section (remote refs, registry, diff tooling) are speculative — implement only if a concrete need arises.

--- a/docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md
+++ b/docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md
@@ -29,7 +29,6 @@ See [Target-Model-Aware Data Conformance](#target-model-aware-data-conformance) 
 - [x] `generated: true` flag on `ColumnSpec` (required generated columns are advisory and do not trigger missing-column conformance errors)
 - [x] `allowed_values` / `type: enum` on `ColumnSpec`
 - [x] Richer FK semantics — bridge entity support via `via` attribute in FK spec
-- [ ] Advanced FK validation modes — `direct`, `transitive`, explicit path constraints
 ~~- [ ] Entity spec inheritance (`extends:`) — defer until 5+ target models exist~~
 
 ### Test Coverage
@@ -38,7 +37,7 @@ See [Target-Model-Aware Data Conformance](#target-model-aware-data-conformance) 
 - [x] Projects without target model — structural validation unaffected, conformance returns empty
 - [x] Missing target model file — graceful handling, treated as no target model rather than a 500
 - [x] Backend adapter integration — `TargetModelValidator` code mapping, endpoint response, category tagging
-- [ ] Warning vs error severity (Phase 4 checks)
+- [x] Warning vs error severity (Phase 4 checks)
 
 ### Infrastructure
 - [x] Rule disabling via `options.validation.disabled_rules`
@@ -49,9 +48,8 @@ See [Target-Model-Aware Data Conformance](#target-model-aware-data-conformance) 
 
 ### Tooling / Ecosystem
 - [x] Target model documentation downloads — Project-aware HTML/Markdown/Excel documentation accessible from UX
-- [ ] Target model diff report (version upgrade planning)
-- [ ] Remote target model references (SSRF-safe, with caching)
-- [ ] Curated target model registry (bundled YAML short-name resolution)
+
+Speculative tooling and ecosystem follow-up items have been moved to [docs/proposals/future/TARGET_MODEL_ECOSYSTEM_ENHANCEMENTS.md](future/TARGET_MODEL_ECOSYSTEM_ENHANCEMENTS.md).
 
 ### SEAD spec coverage (`resources/target_models/sead_superset_model.yml`)
 - [x] Abundance chain — `abundance`, `abundance_element`, `abundance_element_group`, `abundance_modification`, `modification_type`, `abundance_property`
@@ -158,77 +156,7 @@ site_location:
 
 Many-to-many relationships are common in relational models. The `via` attribute makes bridge patterns explicit in the target model specification, enabling validators to understand transitive FK relationships without requiring deep graph traversal. This documents intent and prevents false positives when the direct FK relationship doesn't exist.
 
-### Advanced FK Validation Modes — Future Enhancement
-
-The current bridge entity support (`via` attribute) handles the most common many-to-many pattern. Future enhancements could add more flexible FK validation modes to handle complex relationship patterns.
-
-**Proposed FK validation mode attributes:**
-
-```yaml
-# Mode 1: Direct FK only (no transitive relationships allowed)
-entity_a:
-  foreign_keys:
-    - entity: entity_b
-      direct: true          # Must be a direct FK, fail if only transitive path exists
-      required: true
-
-# Mode 2: Bridge-mediated (current implementation)
-entity_a:
-  foreign_keys:
-    - entity: entity_c
-      via: bridge_entity    # Must go through specific bridge entity
-      required: true
-
-# Mode 3: Transitive FK (any path allowed)
-entity_a:
-  foreign_keys:
-    - entity: entity_d
-      transitive: true      # Can be satisfied by any FK chain (BFS/DFS walk)
-      required: true
-      max_depth: 3          # Optional: limit transitive search depth
-
-# Mode 4: Explicit path constraint
-entity_a:
-  foreign_keys:
-    - entity: entity_e
-      path: [intermediary_1, intermediary_2]  # Must follow specific FK chain
-      required: true
-```
-
-**Validation strategies:**
-
-1. **Direct mode** (`direct: true`)
-   - Default if no mode specified
-   - Check that target entity appears in source's immediate FK targets
-   - Reject transitive paths
-
-2. **Bridge mode** (`via: bridge_name`)
-   - Current implementation ✅
-   - Validate bridge presence in direct FK targets
-   - Validate bridge has FK to ultimate target
-
-3. **Transitive mode** (`transitive: true`)
-   - BFS/DFS graph walk through FK graph
-   - Accept any valid FK chain from source to target
-   - Optional `max_depth` to prevent infinite loops
-   - Performance consideration: may require full FK graph construction
-
-4. **Explicit path mode** (`path: [...]`)
-   - Validate that each entity in path has FK to next entity
-   - Strictest validation: only accept specified route
-   - Use case: documenting canonical FK traversal paths
-
-**Implementation considerations:**
-
-- **Mutual exclusivity**: Only one mode per FK spec (enforced by Pydantic validators)
-- **Default behavior**: No mode specified = `direct: true` (backward compatible)
-- **Performance**: Transitive and path modes require FK graph access (may need `ProcessState` or equivalent)
-- **False positive risk**: Transitive mode may be too permissive; use with caution
-
-**Deferred until:**
-- Real-world use cases demonstrate need for modes beyond `via`
-- FK graph structure is stable and available at validation time
-- Performance implications of graph traversal are analyzed
+Advanced FK validation modes are no longer part of this active CR. The deferred design work now lives in [docs/proposals/future/ADVANCED_FK_VALIDATION_MODES.md](future/ADVANCED_FK_VALIDATION_MODES.md).
 
 ---
 
@@ -242,11 +170,11 @@ Check global modeling requirements that depend on understanding the *combination
 
 **Implemented rule:** `no_orphan_facts` — when the target model declares `constraints: [{type: no_orphan_facts}]`, each fact entity present in the project must be linked (directly or transitively) to at least one lookup or classifier entity declared in the target model.
 
-**Implementation note:** The rule reuses the same target-facing FK graph walk used by transitive foreign-key conformance. It runs only when the global constraint is declared, so target models that do not opt in keep current behavior.
+**Implementation note:** The rule reuses the same target-facing FK graph walk used by transitive foreign-key conformance. It runs only when the global constraint is declared, so target models that do not opt in keep current behavior. It now emits a warning by default and upgrades to an error when the constraint is declared with `required: strict`. Projects can still override the severity via `options.validation.severity_overrides.no_orphan_facts`.
 
 ### Source-Type Appropriateness
 
-Classifiers declared with `role: classifier` should use `type: fixed` or `type: sql` rather than `type: entity`. Emit a warning when a classifier is configured as a row-extraction entity.
+Classifiers declared with `role: classifier` should use `type: fixed` or `type: sql` rather than `type: entity`. The implemented rule emits a warning when a classifier is configured as a row-extraction entity. Projects can override that severity via `options.validation.severity_overrides.source_type_appropriateness`.
 
 **Difficulty:** Low. Single-pass check against entity type field.
 
@@ -504,7 +432,7 @@ A project may satisfy a required FK transitively through an intermediate entity 
 
 **Status:** Implemented. `ForeignKeyConformanceValidator` now walks the project's target-facing FK graph before emitting `MISSING_REQUIRED_FOREIGN_KEY_TARGET`, which removes direct-only false positives such as `sample → sample_group → site`.
 
-**Current limitation:** This is path detection only. The format-level FK modes proposed earlier (`direct`, `transitive`, explicit `path`) are still deferred.
+**Current limitation:** This is path detection only. Format-level FK modes such as `direct`, `transitive`, and explicit `path` constraints have been moved to [docs/proposals/future/ADVANCED_FK_VALIDATION_MODES.md](future/ADVANCED_FK_VALIDATION_MODES.md).
 
 ### Value-Level Checks
 
@@ -591,8 +519,11 @@ These test areas were identified in the implementation sketch but not yet covere
 
 ### Warning vs Error Severity (Phase 4)
 
-- Orphan-fact check is configurable (warning by default, error when `required: strict`)
-- Severity can be overridden via `options.validation.severity_overrides`
+**Implemented:**
+
+- `no_orphan_facts` emits a warning by default and upgrades to an error when the target model declares `required: strict`
+- `source_type_appropriateness` emits a warning by default
+- Projects can override registered conformance-rule severities via `options.validation.severity_overrides`
 
 ### Missing Target Model File
 
@@ -637,39 +568,13 @@ Should projects be able to suppress specific conformance rules?
 
 **Current state:** Implemented for registered target-model conformance validators. Unknown rule keys produce a warning instead of being silently ignored.
 
-**Recommendation:** Keep this limited to registry-key filtering for conformance validators until there is a concrete need for severity overrides or broader validation-rule scoping.
+**Recommendation:** Keep both `disabled_rules` and `severity_overrides` limited to registered conformance validator keys until there is a concrete need for broader validation-rule scoping.
 
 ---
 
 ## Future Enhancements
 
-### Target Model Diff Tooling
-
-When a target model version changes, provide a diff report showing which conformance checks are new, changed, or removed. Useful for upgrade planning.
-
-**Approach:** Compare two `TargetModel` instances field-by-field. Output a structured diff as YAML or markdown.
-
-### Remote Target Model References
-
-Allow `target_model: "https://registry.example.com/sead/v2.yml"` in addition to `@include:` file references.
-
-**Prerequisites:**
-- SSRF prevention (allowlist of permitted domains or a local proxy)
-- Caching with TTL to avoid network calls on every validation
-- Version pinning to prevent silent breakage on upstream changes
-
-**Recommendation:** Only implement if a shared community registry becomes real. Local file references cover all current use cases.
-
-### Curated Target Model Registry
-
-A registry of community-contributed target models distributed alongside Shape Shifter or via a companion package.
-
-**Candidates:**
-- `sead_standard_model` — SEAD Clearinghouse v2 (already exists in `resources/target_models/`)
-- Generic archaeological site model
-- Museum specimen model
-
-**Approach:** Bundled YAML files in `resources/target_models/`, referenced by short name without a path. The mapper resolves short names to the bundled file before resolving `@include:`.
+Speculative target-model tooling and ecosystem work has been moved to [docs/proposals/future/TARGET_MODEL_ECOSYSTEM_ENHANCEMENTS.md](future/TARGET_MODEL_ECOSYSTEM_ENHANCEMENTS.md).
 
 ### Target Model Documentation Downloads
 

--- a/docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md
+++ b/docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md
@@ -15,7 +15,7 @@
 - [x] `induced_requirements` — optional entity present → its required FK targets are induced-required (transitive)
 - [x] `source_type_appropriateness` — classifiers should not use `type: entity`
 - [x] `no_orphan_facts` — fact entities must have a direct or transitive FK path to at least one lookup or classifier when the global constraint is declared
-- [ ] `schema_aware_append` — appended columns conform to target model column spec
+- [x] `schema_aware_append` — append branches satisfy the parent's required target-model column contract after append renaming is applied
 
 ### Data Conformance Validators
 - [x] `nullable` — required-not-null columns must have no null values in produced data
@@ -77,7 +77,7 @@ This proposal consolidates deferred and future items from:
 
 ## What Is Already Implemented
 
-Eight conformance validators are registered and active:
+Nine conformance validators are registered and active:
 
 | Key                            | What it checks                                                                            |
 |--------------------------------|-------------------------------------------------------------------------------------------|
@@ -89,6 +89,7 @@ Eight conformance validators are registered and active:
 | `induced_requirements`         | If optional entity X is present and has a required FK to Y, then Y is required (transitively) |
 | `source_type_appropriateness`  | Classifiers (`role: classifier`) must use `type: fixed` or `type: sql`, not `type: entity` |
 | `no_orphan_facts`              | Fact entities present in the project must reach at least one lookup or classifier when the target model declares that global constraint |
+| `schema_aware_append`          | Each append branch must provide the parent's required target-facing columns after `align_by_position` or `column_mapping` is applied |
 
 Backend wiring, frontend Check Conformance button, and Conformance panel in ValidationPanel are all live.
 
@@ -233,7 +234,7 @@ entity_a:
 
 ## Advanced Semantic Validation (Phase 4)
 
-These items were labeled "Phase 4 — Advanced Semantic Rules" in the implementation sketch. None are implemented.
+These items were labeled "Phase 4 — Advanced Semantic Rules" in the implementation sketch. Some remain deferred, but `no_orphan_facts` and `schema_aware_append` are now implemented.
 
 ### Global Role-Informed Checks
 
@@ -251,7 +252,11 @@ Classifiers declared with `role: classifier` should use `type: fixed` or `type: 
 
 ### Schema-Aware Append Conformance
 
-When a project uses append mode, validate that the appended columns conform to the target-model column spec for that entity. Currently append operations are not checked against the target model at all.
+**Implemented rule:** `schema_aware_append` — when a project entity uses `append`, each append branch is checked against the subset of required target-model columns already exposed by the parent entity's target-facing contract.
+
+This closes the gap where the parent entity looks conformant, but one append source still contributes rows that are missing required target-facing columns or omit expected FK-facing columns.
+
+**Implementation note:** The validator applies static append renaming before checking branch shape, so `align_by_position` and `column_mapping` are treated as part of the append contract. It emits `APPEND_MISSING_REQUIRED_COLUMN` only for required target-model columns that the parent entity already exposes, which avoids duplicating the base required-column errors when the parent entity is itself non-conformant.
 
 ### Branch-Aware Semantic Validation
 

--- a/docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md
+++ b/docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md
@@ -41,7 +41,7 @@ See [Target-Model-Aware Data Conformance](#target-model-aware-data-conformance) 
 
 ### Infrastructure
 - [x] Rule disabling via `options.validation.disabled_rules`
-- [ ] `GlobalConformanceValidator` base type for multi-entity checks
+- [x] `GlobalConformanceValidator` base type for multi-entity checks
 - [ ] `TargetModelService` — extract loading/caching when remote refs become real
 - [x] Target model YAML editor tab — raw YAML edit tab for the project's **project-local** target model file alongside the project YAML tab
 - [x] Monaco editor schema support for target model YAML files — autocomplete and IntelliSense using `targetModelSchema.json`

--- a/docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md
+++ b/docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md
@@ -26,7 +26,7 @@ See [Target-Model-Aware Data Conformance](#target-model-aware-data-conformance) 
 
 ### Format Extensions
 - [x] `format_version` field in `model:` block
-- [ ] `generated: true` flag on `ColumnSpec` (suppress missing-column warnings for auto-generated columns)
+- [x] `generated: true` flag on `ColumnSpec` (required generated columns are advisory and do not trigger missing-column conformance errors)
 - [ ] `allowed_values` / `type: enum` on `ColumnSpec`
 - [x] Richer FK semantics — bridge entity support via `via` attribute in FK spec
 - [ ] Advanced FK validation modes — `direct`, `transitive`, explicit path constraints
@@ -552,7 +552,7 @@ Add `allowed_values` or `type: enum` to `ColumnSpec` for validating classifier c
 
 Should the target model spec record which columns have database defaults or are auto-generated?
 
-**Recommendation:** Advisory only. Add an optional `generated: true` flag that validators can use to suppress "column not present in source" warnings. Not normative.
+**Implemented:** `ColumnSpec.generated: true` is now available as advisory metadata. Required columns marked this way are kept in the format and generated schema/docs, but the structural conformance checks skip missing-column errors for them, including append-branch column checks.
 
 ### Inheritance / Mixins for Entity Templates
 

--- a/docs/proposals/done/SEAD_V2_IMPLEMENTATION_PLAN.md
+++ b/docs/proposals/done/SEAD_V2_IMPLEMENTATION_PLAN.md
@@ -6,8 +6,8 @@ This document tracks the implementation phases for the first SEAD target-model s
 
 It complements, but does not replace:
 
-- `docs/proposals/TARGET_MODEL_SPECIFICATION_FORMAT.md` for the format contract and semantics
-- `docs/proposals/TARGET_SCHEMA_AWARE_VALIDATION.md` for how Shape Shifter consumes target models during validation
+- `docs/proposals/done/TARGET_MODEL_SPECIFICATION_FORMAT.md` for the format contract and semantics
+- `docs/proposals/done/TARGET_SCHEMA_AWARE_VALIDATION.md` for how Shape Shifter consumes target models during validation
 
 The goal here is practical sequencing: what must be decided before drafting, what will be delivered in the first iterations, and what is explicitly deferred.
 
@@ -18,10 +18,10 @@ The words `phase` and `iteration` mean different things in this document.
 - **Phase** = a broad stage of work with a distinct goal and exit criteria.
 - **Iteration** = one pass within a phase where we refine the output using real examples, feedback, or tests.
 
-In practice:
+In this completed roadmap:
 
-- We are currently using **phases** to describe the roadmap.
-- We use **iterations** to describe refinement loops within a phase.
+- **phases** describe the delivery stages that were used
+- **iterations** describe the refinement loops that happened within those stages
 
 Examples:
 
@@ -31,7 +31,7 @@ Examples:
 
 For the next stretch of work, the important distinction is:
 
-- we can add new **phases** for standalone conformance-validation work inside `target_models/`
+- we can add new **phases** for standalone conformance-validation work inside the target-model implementation track
 - and still expect multiple **iterations** within those phases before any backend integration is justified
 
 ## Proposal Milestone Tracking
@@ -53,15 +53,15 @@ Checklist:
 - [x] Spec validation exists for the current standalone target-model format
 - [x] Standalone conformance validation exists for project-versus-target checks
 - [x] The current standalone format supports entities, roles, required, nullability, identity_columns, unique_sets, domains, foreign_keys, naming, and constraint declarations
-- [x] The current standalone SEAD spec covers the Milestone 1 core spine and additional iteration-1 entities in `resources/target_modelsdels/sead_standard_model.yml`
-- [x] The proposal now treats `resources/target_modelsdels/sead_standard_model.yml` as the working version until Shape Shifter integration is completed
+- [x] The current standalone SEAD spec covers the Milestone 1 core spine and additional iteration-1 entities in `resources/target_models/sead_standard_model.yml`
+- [x] The proposal now treats `resources/target_models/sead_standard_model.yml` as the working version until Shape Shifter integration is completed
 - [x] Implementation matches the current proposal column contract (mapping-based `columns` with logical `type` metadata)
 - [x] Proposal and implementation are aligned tightly enough to claim "without schema changes"
 
 Current status:
 - **Milestone 1 is complete.**
 - The parser, standalone validators, and working core SEAD spec all exist.
-- The proposal now matches the current standalone reality: until integration is completed, the working `sead_standard_model.yml` remains in `resources/target_modelsdels/sead_standard_model.yml` and uses the implemented mapping-based column contract with logical `type` metadata.
+- The proposal now matches the current standalone reality: until integration is completed, the working `sead_standard_model.yml` remains in `resources/target_models/sead_standard_model.yml` and uses the implemented mapping-based column contract with logical `type` metadata.
 
 ### Milestone 2: Expanded Coverage
 
@@ -73,7 +73,7 @@ Proposal intent:
 Checklist:
 - [x] Resolve the Milestone 1 proposal-versus-implementation alignment gaps
 - [x] Expand the canonical SEAD spec toward the current Milestone 2 backlog: abundance, dating, method/contact, and taxonomy coverage
-- [x] Reach the explicit Milestone 2 target of 20-24 total entities in `resources/target_modelsdels/sead_standard_model.yml`
+- [x] Reach the explicit Milestone 2 target of 20-24 total entities in `resources/target_models/sead_standard_model.yml`
 - [x] Reach the preferred planning target of 23 total entities if all currently named Milestone 2 backlog entities remain in scope
 - [x] Add a template-generation proof of concept using the target model, optionally filtered by domain/profile
 - [x] Validate the expanded model with parser, spec-validation, and conformance tests
@@ -151,8 +151,8 @@ Decision:
 ### 0.2 Canonical spec location
 
 Decision:
-- During format iteration, the SEAD spec lives at `resources/target_modelsdels/sead_standard_model.yml`
-- Phase documents and implementation notes live under `target_models/docs/`
+- During format iteration, the SEAD spec lives at `resources/target_models/sead_standard_model.yml`
+- Phase documents and implementation notes live under `docs/proposals/done/`
 
 ### 0.3 Iteration-1 entity set
 
@@ -269,14 +269,14 @@ Goals:
 - [x] Format proposal points to the implementation plan
 - [x] Format proposal no longer carries phased rollout content
 - [x] Validation proposal uses the canonical top-level target-model shape
-- [x] Validation proposal points to `resources/target_modelsdels/sead_standard_model.yml`
+- [x] Validation proposal points to `resources/target_models/sead_standard_model.yml`
 - [x] Implementation sketch is aligned with the current format
 - [x] All phase-related cross-references are consistent
 
 Deliverables:
-- `docs/proposals/TARGET_MODEL_SPECIFICATION_FORMAT.md`
-- `docs/proposals/TARGET_SCHEMA_AWARE_VALIDATION.md`
-- `docs/proposals/TARGET_SCHEMA_AWARE_VALIDATION_IMPLEMENTATION_SKETCH.md`
+- `docs/proposals/done/TARGET_MODEL_SPECIFICATION_FORMAT.md`
+- `docs/proposals/done/TARGET_SCHEMA_AWARE_VALIDATION.md`
+- `docs/proposals/done/TARGET_SCHEMA_AWARE_VALIDATION_IMPLEMENTATION_SKETCH.md`
 
 Exit criteria:
 - The docs no longer disagree on structure, location, or iteration-1 scope
@@ -306,12 +306,12 @@ Exit criteria:
 ## Phase 3: Author First SEAD Draft
 
 Goals:
-- Produce the first usable `resources/target_modelsdels/sead_standard_model.yml`
+- Produce the first usable `resources/target_models/sead_standard_model.yml`
 - Cover only the iteration-1 core entities with minimal metadata
 
 ### Checklist
 
-- [x] `resources/target_modelsdels/sead_standard_model.yml` created
+- [x] `resources/target_models/sead_standard_model.yml` created
 - [x] Iteration-1 core entities present in the draft
 - [x] `target_table` mappings added for iteration-1 entities
 - [x] `public_id` mappings added for iteration-1 entities
@@ -323,7 +323,7 @@ Goals:
 - [x] Draft cross-checked against SEAD source schema and a real Shape Shifter project
 
 Deliverables:
-- `resources/target_modelsdels/sead_standard_model.yml`
+- `resources/target_models/sead_standard_model.yml`
 
 Iteration-1 content rules:
 - Prefer minimal but correct metadata over broad but speculative coverage
@@ -408,18 +408,18 @@ Goals:
 
 - [x] Run the standalone conformance validator against multiple real project fixtures
 - [x] Classify findings into stable errors, warnings, and deferred heuristics
-- [x] Record false positives and ambiguous cases in `target_models/docs/`
+- [x] Record false positives and ambiguous cases in `docs/proposals/done/`
 - [x] Confirm whether `sead_standard_model.yml` needs refinement based on real project evidence
 - [x] Identify the minimal check set safe for eventual backend integration
 
 Deliverables:
 - Refined conformance tests
-- Notes on noisy versus stable rules in `target_models/docs/TARGET_MODEL_CONFORMANCE_REFINEMENT.md`
+- Notes on noisy versus stable rules in `docs/proposals/done/TARGET_MODEL_CONFORMANCE_REFINEMENT.md`
 - A documented minimal rule set for future backend integration
 
 Current Phase 6 decision:
 - Keep `sead_standard_model.yml` canonical and unchanged for now; the current real-project evidence does not justify alias metadata or weaker conformance semantics.
-- Freeze the standalone integration candidate to the conservative checks already documented in `target_models/docs/TARGET_MODEL_CONFORMANCE_REFINEMENT.md`.
+- Freeze the standalone integration candidate to the conservative checks already documented in `docs/proposals/done/TARGET_MODEL_CONFORMANCE_REFINEMENT.md`.
 - Treat Phase 6 as complete for the current standalone conformance-refinement scope.
 
 Exit criteria:
@@ -440,14 +440,14 @@ Goals:
 
 ### Checklist
 
-- [x] Draft the abundance package in `resources/target_modelsdels/sead_standard_model.yml`: `abundance`, `abundance_element`, `abundance_element_group`, `abundance_modification`, `abundance_property`
-- [x] Draft the dating package in `resources/target_modelsdels/sead_standard_model.yml`: `relative_ages`, `relative_dating`, `geochronology`, `dating_lab`
-- [x] Draft the method/contact package in `resources/target_modelsdels/sead_standard_model.yml`: `method_group`, `contact`, `contact_type`
-- [x] Draft the taxonomy package in `resources/target_modelsdels/sead_standard_model.yml`: `taxa_tree_master`, `taxa_common_names`
+- [x] Draft the abundance package in `resources/target_models/sead_standard_model.yml`: `abundance`, `abundance_element`, `abundance_element_group`, `abundance_modification`, `abundance_property`
+- [x] Draft the dating package in `resources/target_models/sead_standard_model.yml`: `relative_ages`, `relative_dating`, `geochronology`, `dating_lab`
+- [x] Draft the method/contact package in `resources/target_models/sead_standard_model.yml`: `method_group`, `contact`, `contact_type`
+- [x] Draft the taxonomy package in `resources/target_models/sead_standard_model.yml`: `taxa_tree_master`, `taxa_common_names`
 - [x] Reach the explicit Milestone 2 target of 20-24 total entities in the working SEAD spec
 - [x] Reach the preferred planning target of 23 total entities if all currently named backlog entities remain in scope
-- [x] Update `docs/proposals/TARGET_MODEL_SPECIFICATION_FORMAT.md` so its milestone language, examples, and success criteria reflect the expanded-coverage target
-- [x] Update `target_models/docs/SEAD_V2_IMPLEMENTATION_PLAN.md` to track the Milestone 2 completion work and any scope decisions made during expansion
+- [x] Update `docs/proposals/done/TARGET_MODEL_SPECIFICATION_FORMAT.md` so its milestone language, examples, and success criteria reflect the expanded-coverage target
+- [x] Update `docs/proposals/done/SEAD_V2_IMPLEMENTATION_PLAN.md` to track the Milestone 2 completion work and any scope decisions made during expansion
 - [x] Decide and document the minimum acceptable template-generation proof of concept for Milestone 2
 - [x] Add or update parser, spec-validation, and conformance tests to cover the expanded entity set and any new format decisions
 - [x] Reassess whether any newly observed ambiguities belong in deferred format issues versus the Milestone 2 scope
@@ -455,7 +455,7 @@ Goals:
 ### Milestone 2 Backlog Basis
 
 Current baseline:
-- 23 entities now exist in `resources/target_modelsdels/sead_standard_model.yml`
+- 23 entities now exist in `resources/target_models/sead_standard_model.yml`
 
 Remaining named expansion backlog:
 - 0 additional entities remain in scope for Milestone 2
@@ -466,8 +466,8 @@ Planning arithmetic:
 - Treat 23 entities as the preferred planning target because it corresponds to the full currently named Milestone 2 backlog
 
 Deliverables:
-- Expanded `resources/target_modelsdels/sead_standard_model.yml`
-- Updated milestone and roadmap documentation in `docs/proposals/` and `target_models/docs/`
+- Expanded `resources/target_models/sead_standard_model.yml`
+- Updated milestone and roadmap documentation in `docs/proposals/done/`
 - Test coverage proving the expanded target model still loads and validates cleanly
 - A working standalone template-generation proof of concept plus its documentation
 
@@ -478,7 +478,7 @@ Purpose:
 
 Minimum scope:
 - A standalone script or notebook is sufficient; backend integration is not required for Milestone 2.
-- Input is the working target model at `resources/target_modelsdels/sead_standard_model.yml` plus an optional domain filter or explicit entity allowlist/profile.
+- Input is the working target model at `resources/target_models/sead_standard_model.yml` plus an optional domain filter or explicit entity allowlist/profile.
 - Output is a non-runnable starter scaffold in `shapeshifter.yml` style that is meant to be completed by a human author.
 
 Required output content:
@@ -536,9 +536,9 @@ Goals:
 
 - [x] Add a follow-on roadmap phase before backend integration so expanded standalone coverage is represented explicitly
 - [x] Update proposal and implementation-plan text so the current coverage and next-step sequencing match the implementation
-- [x] Draft a first common-entity package in `resources/target_modelsdels/sead_standard_model.yml`: `project`, `feature`, `feature_type`, `modification_type`, `sample_description`, `sample_description_type`, `site_type`, `site_type_group`
+- [x] Draft a first common-entity package in `resources/target_models/sead_standard_model.yml`: `project`, `feature`, `feature_type`, `modification_type`, `sample_description`, `sample_description_type`, `site_type`, `site_type_group`
 - [x] Improve related existing entities where the new package adds clearer target-model relationships (`dataset -> project`, `site -> site_type`, `abundance_modification -> modification_type`)
-- [x] Draft a second common/provenance bridge package in `resources/target_modelsdels/sead_standard_model.yml`: `citation`, `master_dataset`, `dataset_contact`, `sample_feature`
+- [x] Draft a second common/provenance bridge package in `resources/target_models/sead_standard_model.yml`: `citation`, `master_dataset`, `dataset_contact`, `sample_feature`
 - [x] Improve related existing entities where the new package adds clearer target-model relationships (`dataset -> master_dataset`, `dataset -> citation`, `method -> citation`, `sample <-> feature` via `sample_feature`, `dataset <-> contact` via `dataset_contact`)
 - [x] Reach roughly 30 total entities in the working SEAD spec without promoting Milestone 3 to complete
 - [x] Update standalone validation tests to cover the new common-entity package
@@ -551,7 +551,7 @@ Current status:
 - Still-deferred entities such as `sample_coordinate` and other alias-heavy mappings remain good candidates for later work, but they need either richer target metadata or broader conformance semantics to avoid noisy false positives.
 
 Deliverables:
-- A 35-entity working `resources/target_modelsdels/sead_standard_model.yml`
+- A 35-entity working `resources/target_models/sead_standard_model.yml`
 - Updated proposal and implementation-plan language for the post-23-entity standalone expansion
 - Updated standalone spec-validation coverage for the new entity package
 
@@ -576,7 +576,7 @@ Goals:
 - [x] Keep non-integrated experimental rules outside the backend path
 
 Deliverables:
-- Core conformance migration work described in `docs/proposals/TARGET_SCHEMA_AWARE_VALIDATION_IMPLEMENTATION_SKETCH.md`
+- Core conformance migration work described in `docs/proposals/done/TARGET_SCHEMA_AWARE_VALIDATION_IMPLEMENTATION_SKETCH.md`
 
 Exit criteria:
 - Target-model-aware validation runs against the resolved core project model and no longer depends on a duplicate standalone project-side conformance model

--- a/docs/proposals/done/SEAD_V2_IMPLEMENTATION_PLAN.md
+++ b/docs/proposals/done/SEAD_V2_IMPLEMENTATION_PLAN.md
@@ -583,9 +583,9 @@ Exit criteria:
 
 ## Future Phase: Deferred Issues
 
-Milestones 1–3 are complete. All deferred format issues, validation issues, and SEAD coverage issues have been consolidated into [docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](../../docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md).
+Milestones 1–3 are complete. The consolidated follow-through record lives in [docs/proposals/done/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](../../docs/proposals/done/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md).
 
 ## Near-Term Order
 
-Milestones 1–3 are complete. For remaining backlog and suggested resumption order, see [docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](../../docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md).
+Milestones 1–3 are complete. For the closed consolidation record and deferred follow-up notes, see [docs/proposals/done/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](../../docs/proposals/done/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md).
 8. Revisit backend integration only after the standalone validator and expanded standalone coverage have stabilized.

--- a/docs/proposals/done/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md
+++ b/docs/proposals/done/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-**Active — backlog.** Core conformance engine (Milestones 1–3) is complete. This proposal tracks the remaining deferred and future work gathered from five now-archived source documents.
+**Closed — implemented or deferred.** The delivered conformance and format work in this proposal is complete. Remaining heuristic follow-up is now tracked in GitHub issue #457, and ecosystem-dependent work lives in future proposals.
 
 ## Implementation Checklist
 
@@ -42,14 +42,15 @@ See [Target-Model-Aware Data Conformance](#target-model-aware-data-conformance) 
 ### Infrastructure
 - [x] Rule disabling via `options.validation.disabled_rules`
 - [x] `GlobalConformanceValidator` base type for multi-entity checks
-- [ ] `TargetModelService` — extract loading/caching when remote refs become real
 - [x] Target model YAML editor tab — raw YAML edit tab for the project's **project-local** target model file alongside the project YAML tab
 - [x] Monaco editor schema support for target model YAML files — autocomplete and IntelliSense using `targetModelSchema.json`
+
+Deferred target-model loading and caching extraction has been moved to [docs/proposals/future/TARGET_MODEL_ECOSYSTEM_ENHANCEMENTS.md](../future/TARGET_MODEL_ECOSYSTEM_ENHANCEMENTS.md).
 
 ### Tooling / Ecosystem
 - [x] Target model documentation downloads — Project-aware HTML/Markdown/Excel documentation accessible from UX
 
-Speculative tooling and ecosystem follow-up items have been moved to [docs/proposals/future/TARGET_MODEL_ECOSYSTEM_ENHANCEMENTS.md](future/TARGET_MODEL_ECOSYSTEM_ENHANCEMENTS.md).
+Speculative tooling and ecosystem follow-up items have been moved to [docs/proposals/future/TARGET_MODEL_ECOSYSTEM_ENHANCEMENTS.md](../future/TARGET_MODEL_ECOSYSTEM_ENHANCEMENTS.md).
 
 ### SEAD spec coverage (`resources/target_models/sead_superset_model.yml`)
 - [x] Abundance chain — `abundance`, `abundance_element`, `abundance_element_group`, `abundance_modification`, `modification_type`, `abundance_property`
@@ -59,7 +60,7 @@ Speculative tooling and ecosystem follow-up items have been moved to [docs/propo
 - [x] Analysis-value family and shared lookups — `analysis_value`, `analysis_note`, `analysis_identifier`, typed analysis value entities, `property_type`, `value_class`, `value_type`, `value_type_item`, `value_qualifier`, `value_qualifier_symbol`
 - [x] Property and lookup follow-up coverage — `site_property`, `feature_property`, `site_natgridref`, `coordinate_system`, `colour`, `sample_colour`, `project_type`, `project_stage`, `taxa_synonyms`, `taxa_measured_attributes`, `rdb`, `rdb_code`, `rdb_system`
 - [x] Taxonomy — `taxa_tree_master`, `taxa_common_names`, `taxa_synonyms`, `taxa_measured_attributes`, `ecocode_system`, `ecocode_group`, `ecocode_definition`, `ecocode`, `taxonomic_order_system`, `taxonomic_order`, `rdb`, `rdb_code`, and `rdb_system`
-~~- [ ] Data-type-specific tables (ceramics, dendrochronology, insects)~~ — legacy or specialized method-specific tables are not part of the current shared `sead_superset_model.yml` boundary; see [docs/proposals/done/SEAD_V2_TARGET_MODEL_COMPLETENESS.md](done/SEAD_V2_TARGET_MODEL_COMPLETENESS.md)
+~~- [ ] Data-type-specific tables (ceramics, dendrochronology, insects)~~ — legacy or specialized method-specific tables are not part of the current shared `sead_superset_model.yml` boundary; see [docs/proposals/done/SEAD_V2_TARGET_MODEL_COMPLETENESS.md](SEAD_V2_TARGET_MODEL_COMPLETENESS.md)
 
 ---
 
@@ -156,7 +157,7 @@ site_location:
 
 Many-to-many relationships are common in relational models. The `via` attribute makes bridge patterns explicit in the target model specification, enabling validators to understand transitive FK relationships without requiring deep graph traversal. This documents intent and prevents false positives when the direct FK relationship doesn't exist.
 
-Advanced FK validation modes are no longer part of this active CR. The deferred design work now lives in [docs/proposals/future/ADVANCED_FK_VALIDATION_MODES.md](future/ADVANCED_FK_VALIDATION_MODES.md).
+Advanced FK validation modes are no longer part of this closed proposal. The deferred design work now lives in [docs/proposals/future/ADVANCED_FK_VALIDATION_MODES.md](../future/ADVANCED_FK_VALIDATION_MODES.md).
 
 ---
 
@@ -432,7 +433,7 @@ A project may satisfy a required FK transitively through an intermediate entity 
 
 **Status:** Implemented. `ForeignKeyConformanceValidator` now walks the project's target-facing FK graph before emitting `MISSING_REQUIRED_FOREIGN_KEY_TARGET`, which removes direct-only false positives such as `sample → sample_group → site`.
 
-**Current limitation:** This is path detection only. Format-level FK modes such as `direct`, `transitive`, and explicit `path` constraints have been moved to [docs/proposals/future/ADVANCED_FK_VALIDATION_MODES.md](future/ADVANCED_FK_VALIDATION_MODES.md).
+**Current limitation:** This is path detection only. Format-level FK modes such as `direct`, `transitive`, and explicit `path` constraints have been moved to [docs/proposals/future/ADVANCED_FK_VALIDATION_MODES.md](../future/ADVANCED_FK_VALIDATION_MODES.md).
 
 ### Value-Level Checks
 
@@ -542,17 +543,7 @@ These test areas were identified in the implementation sketch but not yet covere
 
 ## Open Technical Questions
 
-### 1. Target Model Loading Location
-
-Should `ValidationService` load and parse the target model directly, or should there be a dedicated `TargetModelLoader` service?
-
-**Current behaviour:** `ValidationService.validate_target_model()` extracts the resolved `target_model` dict from the mapped core project and passes it to `TargetModelConformanceValidator`.
-
-**Question:** As target model loading gains complexity (caching, remote refs, registry lookups), should this be extracted to a `TargetModelService`?
-
-**Recommendation:** Extract to `TargetModelService` when remote references or caching become real requirements. For now, keep it in `ValidationService`.
-
-### 2. Validation Code Naming
+### 1. Validation Code Naming
 
 Should conformance issue codes be prefixed with `TARGET_` (e.g., `TARGET_MISSING_REQUIRED_ENTITY`, `TARGET_PUBLIC_ID_NAMING_VIOLATION`)?
 
@@ -560,7 +551,7 @@ Should conformance issue codes be prefixed with `TARGET_` (e.g., `TARGET_MISSING
 
 **Recommendation:** Add prefix when expanding to Phase 4. It makes log messages and issue exports unambiguous.
 
-### 3. Rule Disabling
+### 2. Rule Disabling
 
 Should projects be able to suppress specific conformance rules?
 
@@ -574,7 +565,7 @@ Should projects be able to suppress specific conformance rules?
 
 ## Future Enhancements
 
-Speculative target-model tooling and ecosystem work has been moved to [docs/proposals/future/TARGET_MODEL_ECOSYSTEM_ENHANCEMENTS.md](future/TARGET_MODEL_ECOSYSTEM_ENHANCEMENTS.md).
+Speculative target-model tooling and ecosystem work has been moved to [docs/proposals/future/TARGET_MODEL_ECOSYSTEM_ENHANCEMENTS.md](../future/TARGET_MODEL_ECOSYSTEM_ENHANCEMENTS.md).
 
 ### Target Model Documentation Downloads
 

--- a/docs/proposals/done/TARGET_MODEL_CONFORMANCE_REFINEMENT.md
+++ b/docs/proposals/done/TARGET_MODEL_CONFORMANCE_REFINEMENT.md
@@ -4,7 +4,7 @@ This note records the first standalone conformance-validator findings from the P
 
 It exists to separate low-noise rules that are safe to keep from heuristic checks that need more evidence before backend integration.
 
-**Status:** Findings incorporated. Deferred heuristics and items not yet safe for integration have been consolidated into [docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](../../docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md).
+**Status:** Findings incorporated. Deferred heuristics and items not yet safe for integration are summarized in [docs/proposals/done/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](../../docs/proposals/done/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md).
 
 ## Corpus Used
 
@@ -136,4 +136,4 @@ So the current Phase 6 direction remains:
 
 ## Not Yet Safe For Integration
 
-Deferred items (alias matching, semantic normalization, transitive FK satisfaction, value-level checks, `@value:` expression interpretation) have been consolidated into [docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](../../docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md).
+Deferred items (alias matching, semantic normalization, transitive FK satisfaction, value-level checks, `@value:` expression interpretation) are summarized in [docs/proposals/done/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](../../docs/proposals/done/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md).

--- a/docs/proposals/done/TARGET_MODEL_SPECIFICATION_FORMAT.md
+++ b/docs/proposals/done/TARGET_MODEL_SPECIFICATION_FORMAT.md
@@ -552,7 +552,7 @@ Rejected because it defeats reusability. The whole point is that target model re
 
 ## Open Questions
 
-Deferred format open questions (schema-qualified target_table names, entity spec inheritance, format_version field, richer FK semantics, database defaults, relationship to ENTITY_SEMANTIC_ROLES) have been consolidated into [docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md).
+Deferred format open questions (schema-qualified target_table names, entity spec inheritance, format_version field, richer FK semantics, database defaults, relationship to ENTITY_SEMANTIC_ROLES) are summarized in [TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md).
 
 ## Final Recommendation
 

--- a/docs/proposals/done/TARGET_MODEL_SPECIFICATION_FORMAT.md
+++ b/docs/proposals/done/TARGET_MODEL_SPECIFICATION_FORMAT.md
@@ -3,7 +3,7 @@
 ## Status
 
 - **Format: v1 implemented and stable** — Pydantic domain model, spec validator, and conformance engine are all in `src/target_model/`
-- **SEAD specification: active** — `resources/target_models/sead_standard_model.yml` covers 35 entities across core, spatial, abundance, dating, taxonomy, method/contact, and provenance domains
+- **SEAD specification: implemented** — `resources/target_models/sead_standard_model.yml` covers the delivered core, spatial, abundance, dating, taxonomy, method/contact, and provenance scope described in this proposal
 - **Validator integration: done** — `TargetModelConformanceValidator` runs against resolved `ShapeShiftProject`; backend endpoint and frontend Check Conformance button are wired (see [TARGET_SCHEMA_AWARE_VALIDATION](TARGET_SCHEMA_AWARE_VALIDATION.md))
 - Scope: Specification format (YAML schema + semantics) and initial SEAD model definition
 - Goal: Define a reusable, system-independent format for describing target data model requirements, and produce a concrete SEAD specification as the first consumer
@@ -36,7 +36,7 @@ This means:
 This proposal covers two deliverables developed in parallel:
 
 1. **The format** — A YAML schema defining how to express target model requirements: entities, roles, columns, relationships, naming rules, and constraints.
-2. **SEAD v2 specification** — A concrete file (`sead_standard_model.yml`) that describes the SEAD archaeological database using this format, covering the entities and patterns most commonly used in Shape Shifter projects. Until Shape Shifter integration is completed, the working version lives at `resources/target_models/sead_standard_model.yml`.
+2. **SEAD v2 specification** — A concrete file (`sead_standard_model.yml`) that describes the SEAD archaeological database using this format, covering the entities and patterns most commonly used in Shape Shifter projects. The implemented first-spec version lives at `resources/target_models/sead_standard_model.yml`.
 
 ## Non-Goals
 

--- a/docs/proposals/done/TARGET_SCHEMA_AWARE_VALIDATION.md
+++ b/docs/proposals/done/TARGET_SCHEMA_AWARE_VALIDATION.md
@@ -38,7 +38,7 @@
 
 ### Pending
 
-Naming convention conformance and standalone test migration are complete (Milestone 3). Remaining deferred and future items — including semantic mismatch detection, Phase 4 advanced rules, format extensions, and open technical questions — have been consolidated into [docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md).
+Naming convention conformance and standalone test migration are complete (Milestone 3). The consolidation record for the delivered follow-through and deferred notes lives in [TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md).
 
 ## Summary
 
@@ -110,7 +110,7 @@ This proposal does not:
 
 ### Still absent from any validation path
 
-- Entity semantic roles (fact vs lookup vs classifier) — semantic mismatch detection deferred to [TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md)
+- Entity semantic roles (fact vs lookup vs classifier) — semantic mismatch follow-up is recorded in [TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md)
 - Source type appropriateness (classifiers should use `fixed` or `sql`) — deferred
 - Backend wiring for Phase 4 checks — deferred
 
@@ -247,7 +247,7 @@ metadata:
 - [x] Expected/unexpected public_id checks (`PublicIdConformanceValidator`)
 - [ ] Naming convention checks against project entities — public_id_suffix validated in `TargetModelSpecValidator` only; not yet in conformance
 
-**Phase 2: Semantic Checks** — deferred; see [TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md)
+**Phase 2: Semantic Checks** — see the closed follow-through record in [TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md)
 - [ ] Global role-informed checks such as `no_orphan_facts`
 - [ ] Semantic naming mismatches where entity key and expected identifier clearly diverge
 
@@ -256,7 +256,7 @@ metadata:
 - [ ] Branch-scoped consumer validity
 - [ ] Schema-aware append conformance
 
-Deferred items and open technical questions are tracked in [TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md).
+Deferred items and open technical questions are summarized in [TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md).
 
 ## Architecture Decisions
 
@@ -441,7 +441,7 @@ entities:
 
 ## Open Questions
 
-Deferred open questions (severity defaults, custom validators, multiple target models, target model inheritance, validation configuration / rule disabling) have been consolidated into [docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md).
+Deferred open questions (severity defaults, custom validators, multiple target models, target model inheritance, validation configuration / rule disabling) have been consolidated into [TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md).
 
 ## Final Recommendation
 

--- a/docs/proposals/done/TARGET_SCHEMA_AWARE_VALIDATION.md
+++ b/docs/proposals/done/TARGET_SCHEMA_AWARE_VALIDATION.md
@@ -36,9 +36,9 @@
 - `frontend/src/views/ProjectDetailView.vue` — `useConformanceValidation` imported and wired; `handleConformanceValidate()` handler added; `mergedValidationResult` extended to include conformance results alongside structural and data results
 - `frontend/src/components/MetadataEditor.vue` — **Target Model** combobox added; lists project YAML files as `@include: <file>` suggestions; allows free-text entry; clearable; included in save payload
 
-### Pending
+### Follow-Through
 
-Naming convention conformance and standalone test migration are complete (Milestone 3). The consolidation record for the delivered follow-through and deferred notes lives in [TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md).
+Milestones 1-3 are complete. The delivered follow-through and deferred notes live in [TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md), and the remaining non-ecosystem follow-up is tracked in GitHub issue #457.
 
 ## Summary
 
@@ -108,15 +108,15 @@ This proposal does not:
 - Public ID conformance (missing, unexpected)
 - Spec self-consistency (unknown FK targets, identity columns, unique-set columns, naming conventions)
 
-### Still absent from any validation path
+### Remaining Follow-Up Outside The Current Validation Path
 
-- Entity semantic roles (fact vs lookup vs classifier) — semantic mismatch follow-up is recorded in [TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md)
-- Source type appropriateness (classifiers should use `fixed` or `sql`) — deferred
-- Backend wiring for Phase 4 checks — deferred
+- Branch-aware semantic validation for merged-parent branch coverage
+- Alias matching and semantic normalization heuristics
+- Broader semantic-role mismatch heuristics beyond the delivered role-informed checks
 
 ## Proposed Design
 
-The target-model format is defined in [TARGET_MODEL_SPECIFICATION_FORMAT.md](TARGET_MODEL_SPECIFICATION_FORMAT.md). Implementation details and code-level sketches are documented in [TARGET_SCHEMA_AWARE_VALIDATION_IMPLEMENTATION_SKETCH.md](TARGET_SCHEMA_AWARE_VALIDATION_IMPLEMENTATION_SKETCH.md). Phased rollout for the first SEAD model is tracked in [target_models/docs/SEAD_V2_IMPLEMENTATION_PLAN.md](../../target_models/docs/SEAD_V2_IMPLEMENTATION_PLAN.md).
+The target-model format is defined in [TARGET_MODEL_SPECIFICATION_FORMAT.md](TARGET_MODEL_SPECIFICATION_FORMAT.md). Implementation details and code-level sketches are documented in [TARGET_SCHEMA_AWARE_VALIDATION_IMPLEMENTATION_SKETCH.md](TARGET_SCHEMA_AWARE_VALIDATION_IMPLEMENTATION_SKETCH.md). Phased rollout for the first SEAD model is tracked in [SEAD_V2_IMPLEMENTATION_PLAN.md](SEAD_V2_IMPLEMENTATION_PLAN.md).
 
 ### Key Concepts
 

--- a/docs/proposals/done/TARGET_SCHEMA_AWARE_VALIDATION_IMPLEMENTATION_SKETCH.md
+++ b/docs/proposals/done/TARGET_SCHEMA_AWARE_VALIDATION_IMPLEMENTATION_SKETCH.md
@@ -160,12 +160,12 @@ class TableConfig:
 
 The standalone validator in `target_models/` was a useful prototype but depended on a reduced project model with only literal `columns`, `keys`, a shallow `foreign_keys` list, and `extra_columns`. That model cannot answer conformance questions for projects that use append inheritance, materialized state, unnest transformations, or FK-generated columns. Moving conformance onto `TableConfig` recovers DRY and makes the column contract authoritative.
 
-### Backend Adapter (Pending)
+### Backend Adapter (Implemented)
 
-When backend integration is implemented, the adapter should remain thin:
+Backend integration is complete. The adapter remains thin:
 
 ```python
-# backend/app/validators/target_model_validator.py  — not yet written
+# backend/app/validators/target_model_validator.py
 class TargetModelValidator:
     def validate(self, target_model: TargetModel, project: ShapeShiftProject) -> list[ValidationError]:
         from src.target_model.conformance import TargetModelConformanceValidator
@@ -174,12 +174,12 @@ class TargetModelValidator:
         return [ValidationMapper.to_api_error(issue) for issue in issues]
 ```
 
-## Validation Service Integration (Pending)
+## Validation Service Integration (Implemented)
 
-The integration point will be the existing `ValidationService`:
+The integration point is the existing `ValidationService`:
 
 ```python
-# backend/app/services/validation_service.py  — not yet modified
+# backend/app/services/validation_service.py
 async def validate_project(self, project_name: str, use_target_model: bool = True) -> ValidationResponse:
     api_project = self.project_service.load_project(project_name)
     core_project = ProjectMapper.to_core(api_project)

--- a/docs/proposals/done/TARGET_SCHEMA_AWARE_VALIDATION_IMPLEMENTATION_SKETCH.md
+++ b/docs/proposals/done/TARGET_SCHEMA_AWARE_VALIDATION_IMPLEMENTATION_SKETCH.md
@@ -3,7 +3,7 @@
 ## Status
 
 - **Milestones 1–3: complete** — core engine, backend integration, frontend wiring all done
-- **Remaining backlog:** see [docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md)
+- **Closed follow-through record:** see [TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md)
 - Scope: implementation approach for [TARGET_SCHEMA_AWARE_VALIDATION.md](TARGET_SCHEMA_AWARE_VALIDATION.md)
 
 ## Summary
@@ -227,7 +227,7 @@ Key constraints remain: structural validation stays first; target-model validati
 
 ### Phase 4 and Future Enhancements
 
-Phase 4 advanced semantic rules, future enhancements, and remaining deferred items are tracked in [docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md).
+Phase 4 advanced semantic rules, future enhancements, and remaining deferred items are summarized in [TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md).
 
 ## Testing Strategy
 
@@ -238,8 +238,8 @@ Phase 4 advanced semantic rules, future enhancements, and remaining deferred ite
 
 ### Remaining test areas
 
-Test coverage gaps are tracked in [docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md).
+Test coverage gaps are summarized in [TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md).
 
 ## Open Technical Questions
 
-Open technical questions (target model loading location, validation code naming, rule disabling) are tracked in [docs/proposals/TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md).
+Open technical questions (target model loading location, validation code naming, rule disabling) are summarized in [TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md](TARGET_MODEL_CONFORMANCE_ENHANCEMENTS.md).

--- a/docs/proposals/future/ADVANCED_FK_VALIDATION_MODES.md
+++ b/docs/proposals/future/ADVANCED_FK_VALIDATION_MODES.md
@@ -1,0 +1,122 @@
+# Proposal: Advanced FK Validation Modes
+
+## Status
+
+- Proposed future change
+- Scope: target-model format, core conformance validation, target-model spec validation
+- Goal: let target models say whether a required foreign-key relationship must be direct, may be transitive, or must follow one named path
+
+## Summary
+
+Keep the current `via` support and graph-based FK conformance as the default behavior for now, but reserve a future extension for stricter FK modes. This matters because the current validator can prove that some acceptable path exists, but it cannot express whether the target contract requires a direct FK, a specific bridge, or one canonical traversal path.
+
+## Problem
+
+The current conformance engine answers one broad question: can the source entity reach the required target entity through the project's target-facing FK graph?
+
+That is useful for reducing false positives, but it collapses distinctions that may matter later:
+
+- some relationships are only valid when they are direct
+- some relationships are only valid through one named intermediary
+- some downstream joins, review rules, or documentation depend on a canonical traversal path rather than any reachable path
+
+Without a way to express those distinctions, `required: true` on a foreign key remains intentionally loose.
+
+## Scope
+
+- add optional FK mode attributes to the target-model format
+- define how each mode is validated in core conformance
+- define spec-level consistency rules for mutually exclusive mode settings
+
+## Non-Goals
+
+- changing the current default FK conformance behavior in the near term
+- introducing column-level join-key semantics in the same proposal
+- implementing this work before a real target model needs the extra precision
+
+## Current Behavior
+
+Current FK conformance supports two useful patterns:
+
+- direct target presence via the project's target-facing FK graph
+- explicit bridge mediation with `via`
+
+This already covers the common many-to-many case and the common transitive-path case. What it does not cover is intent about which path is acceptable.
+
+## Proposed Design
+
+### Candidate mode attributes
+
+```yaml
+# Mode 1: Direct FK only
+entity_a:
+  foreign_keys:
+    - entity: entity_b
+      direct: true
+      required: true
+
+# Mode 2: Bridge-mediated
+entity_a:
+  foreign_keys:
+    - entity: entity_c
+      via: bridge_entity
+      required: true
+
+# Mode 3: Transitive FK
+entity_a:
+  foreign_keys:
+    - entity: entity_d
+      transitive: true
+      required: true
+      max_depth: 3
+
+# Mode 4: Explicit path constraint
+entity_a:
+  foreign_keys:
+    - entity: entity_e
+      path: [intermediary_1, intermediary_2]
+      required: true
+```
+
+### Intended semantics
+
+- `direct: true`: require the target to appear in the source entity's immediate FK targets
+- `via: bridge_name`: require a specific bridge entity between source and target
+- `transitive: true`: allow any valid FK chain, optionally capped by `max_depth`
+- `path: [...]`: require one exact ordered traversal path
+
+### Spec validation rules
+
+- only one FK mode should be allowed per FK spec
+- no mode specified should keep current behavior until a breaking-format decision is made
+- `max_depth` should only be valid with `transitive: true`
+- `path` entities must be valid entity names in the same target model
+
+## Risks and Tradeoffs
+
+- more expressive FK semantics make the format harder to explain and validate
+- transitive and explicit-path checks need stable FK graph access and may add cost
+- an overly flexible mode system could turn target models into implementation-specific join plans instead of semantic contracts
+
+## Testing And Validation
+
+- spec-validator coverage for mutually exclusive modes and invalid combinations
+- conformance tests for direct-only, bridge-only, transitive, and explicit-path cases
+- regression tests proving the current default behavior remains unchanged until the feature is intentionally enabled
+
+## Acceptance Criteria
+
+- the format can express direct, bridge-mediated, transitive, and explicit-path FK intent without ambiguity
+- invalid mode combinations are rejected by target-model spec validation
+- conformance can distinguish between any-path success and required-path success
+- current projects without mode attributes keep existing behavior
+
+## Open Questions
+
+- should the long-term default remain permissive path detection or become direct-only when a mode is omitted?
+- should `path` be limited to entity names, or should it eventually support named edge constraints?
+- does `max_depth` belong in the format, or is it an implementation detail?
+
+## Final Recommendation
+
+Keep this work out of the current conformance CR. The need is real, but it is a future format-and-validator design question rather than a low-risk follow-up to the current implementation. Revisit it only when a target model needs stricter FK intent than `via` plus broad path detection can express.

--- a/docs/proposals/future/TARGET_MODEL_ECOSYSTEM_ENHANCEMENTS.md
+++ b/docs/proposals/future/TARGET_MODEL_ECOSYSTEM_ENHANCEMENTS.md
@@ -62,6 +62,16 @@ metadata:
 
 **Recommendation:** Only implement this if a shared registry becomes a real operational need. Local file references cover current use cases.
 
+### Target Model Loading And Caching Service
+
+If remote references or registry resolution are added, extract target-model loading out of `ValidationService` into a dedicated `TargetModelService`.
+
+**Why it belongs here:** The current direct load path is simple and sufficient for local files. A dedicated service only becomes useful once validation and documentation flows need shared caching, remote fetch rules, version pinning, or registry lookups.
+
+**Current behavior:** `ValidationService.validate_target_model()` works directly with the resolved `target_model` dict from the mapped core project.
+
+**Recommendation:** Keep loading in `ValidationService` for the current local-file workflow. Introduce `TargetModelService` only as part of a real remote-reference or registry delivery.
+
 ### Curated Target Model Registry
 
 A registry of community-contributed target models distributed with Shape Shifter or via a companion package.

--- a/docs/proposals/future/TARGET_MODEL_ECOSYSTEM_ENHANCEMENTS.md
+++ b/docs/proposals/future/TARGET_MODEL_ECOSYSTEM_ENHANCEMENTS.md
@@ -1,0 +1,103 @@
+# Proposal: Target Model Ecosystem Enhancements
+
+## Status
+
+- Proposed future change
+- Scope: target-model tooling, reference resolution, registry/distribution workflow
+- Goal: separate speculative ecosystem work from the active conformance CR while keeping the options documented
+
+## Summary
+
+Keep the active conformance proposal focused on implemented and near-term validator work. Move speculative ecosystem features into a separate future proposal covering target-model diff tooling, remote references, and a curated registry.
+
+## Problem
+
+The current conformance proposal had started to accumulate two different kinds of work:
+
+- concrete conformance and format changes that were being implemented in the current CR
+- broader ecosystem ideas that depend on product decisions, operational constraints, or a future distribution model
+
+That mix makes the active proposal harder to read and makes the remaining backlog look more implementation-ready than it really is.
+
+## Scope
+
+- target-model diff tooling for upgrade planning
+- remote target-model references beyond local `@include:` files
+- a curated target-model registry with short-name resolution
+
+## Non-Goals
+
+- changing the current local-file target-model workflow
+- replacing the already implemented target-model documentation downloads
+- implementing any of these features in the current conformance CR
+
+## Current Behavior
+
+Today, Shape Shifter supports project-local or repository-local target-model files resolved through the existing `@include:` workflow. This covers current use cases and avoids network, registry, and version-resolution concerns.
+
+Target-model documentation downloads are already implemented and remain part of the active proposal as shipped functionality.
+
+## Proposed Design
+
+### Target Model Diff Tooling
+
+When a target model version changes, provide a diff report showing which conformance checks, entities, or fields are new, changed, or removed.
+
+**Approach:** Compare two `TargetModel` instances field-by-field and render a structured diff as Markdown or YAML.
+
+### Remote Target Model References
+
+Allow target models to be referenced by URL in addition to local `@include:` files.
+
+```yaml
+metadata:
+  target_model: "https://registry.example.com/sead/v2.yml"
+```
+
+**Prerequisites:**
+
+- SSRF prevention through an allowlist or controlled proxy
+- caching with TTL so validation does not trigger network fetches on every run
+- version pinning or equivalent safeguards so upstream changes do not silently alter validation behavior
+
+**Recommendation:** Only implement this if a shared registry becomes a real operational need. Local file references cover current use cases.
+
+### Curated Target Model Registry
+
+A registry of community-contributed target models distributed with Shape Shifter or via a companion package.
+
+**Candidate bundled models:**
+
+- `sead_standard_model` — SEAD Clearinghouse v2
+- a generic archaeological site model
+- a museum specimen model
+
+**Approach:** Store curated YAML files under a bundled resource path and resolve short names to those files before normal `@include:` resolution.
+
+## Risks and Tradeoffs
+
+- remote references add operational and security requirements that do not exist with local files
+- a registry introduces versioning, support, and governance questions beyond pure code changes
+- diff tooling is useful, but it only becomes valuable once target-model version churn is common enough to justify its maintenance cost
+
+## Testing And Validation
+
+- diff tooling: fixture models with expected structured diffs
+- remote references: resolution, caching, pinning, and SSRF guard coverage
+- registry: short-name resolution, invalid model names, and bundled-resource version coverage
+
+## Acceptance Criteria
+
+- each feature has a concrete product need and delivery owner before implementation starts
+- no remote or registry feature ships without explicit security and caching rules
+- the active conformance proposal remains free of speculative ecosystem scope
+
+## Open Questions
+
+- should remote references ever be allowed directly, or only through a local mirror/proxy?
+- should a curated registry ship in the main repository or in a companion package?
+- what level of semantic change should target-model diff tooling highlight by default?
+
+## Final Recommendation
+
+Treat these as undecided future enhancements, not as remaining work in the current conformance backlog. Revisit them only when a concrete operational or product need appears.

--- a/frontend/src/schemas/targetModelSchema.json
+++ b/frontend/src/schemas/targetModelSchema.json
@@ -264,6 +264,22 @@
         "type": {
           "title": "Type",
           "type": "string"
+        },
+        "required": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "const": "strict",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Required"
         }
       },
       "required": [

--- a/frontend/src/schemas/targetModelSchema.json
+++ b/frontend/src/schemas/targetModelSchema.json
@@ -13,6 +13,26 @@
           "title": "Generated",
           "type": "boolean"
         },
+        "allowed_values": {
+          "items": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              }
+            ]
+          },
+          "title": "Allowed Values",
+          "type": "array"
+        },
         "type": {
           "anyOf": [
             {

--- a/frontend/src/schemas/targetModelSchema.json
+++ b/frontend/src/schemas/targetModelSchema.json
@@ -254,6 +254,11 @@
           "title": "Name",
           "type": "string"
         },
+        "format_version": {
+          "default": "1",
+          "title": "Format Version",
+          "type": "string"
+        },
         "version": {
           "title": "Version",
           "type": "string"

--- a/frontend/src/schemas/targetModelSchema.json
+++ b/frontend/src/schemas/targetModelSchema.json
@@ -8,6 +8,11 @@
           "title": "Required",
           "type": "boolean"
         },
+        "generated": {
+          "default": false,
+          "title": "Generated",
+          "type": "boolean"
+        },
         "type": {
           "anyOf": [
             {

--- a/frontend/src/views/ProjectDetailView.vue
+++ b/frontend/src/views/ProjectDetailView.vue
@@ -662,7 +662,7 @@
           <v-window-item value="yaml">
             <!-- Sub-tab bar: only shown when project has a project-local target model file reference -->
             <v-tabs
-              v-if="typeof selectedProject?.metadata?.target_model === 'string'"
+              v-if="hasEditableTargetModelYaml"
               v-model="activeYamlSubTab"
               density="compact"
               class="mb-3"
@@ -726,7 +726,7 @@
 
               <!-- Target Model sub-tab (only mounted when project has a string target_model file reference) -->
               <v-window-item
-                v-if="typeof selectedProject?.metadata?.target_model === 'string'"
+                v-if="hasEditableTargetModelYaml"
                 value="target-model-yaml"
               >
                 <v-card variant="outlined">
@@ -1172,6 +1172,22 @@ const targetModelYamlSaving = ref(false)
 const targetModelYamlError = ref<string | null>(null)
 const targetModelYamlHasChanges = ref(false)
 const targetModelDocsDownloading = ref(false)
+
+function getProjectLocalTargetModelPath(targetModel: string | null | undefined): string | null {
+  if (!targetModel) {
+    return null
+  }
+
+  const rawPath = targetModel.startsWith('@include:') ? targetModel.slice('@include:'.length).trim() : targetModel.trim()
+  if (!rawPath) {
+    return null
+  }
+
+  return rawPath.includes('/') || rawPath.includes('\\') ? null : rawPath
+}
+
+const editableTargetModelPath = computed(() => getProjectLocalTargetModelPath(selectedProject.value?.metadata?.target_model ?? null))
+const hasEditableTargetModelYaml = computed(() => editableTargetModelPath.value !== null)
 
 // Computed
 const mergedValidationResult = computed(() => {
@@ -2553,6 +2569,12 @@ watch(activeTab, async (newTab) => {
 watch(activeYamlSubTab, async (newSubTab) => {
   if (newSubTab === 'target-model-yaml' && targetModelYamlContent.value === null) {
     await handleLoadTargetModelYaml()
+  }
+})
+
+watch(hasEditableTargetModelYaml, (isEditable) => {
+  if (!isEditable && activeYamlSubTab.value === 'target-model-yaml') {
+    activeYamlSubTab.value = 'project-yaml'
   }
 })
 

--- a/frontend/src/views/__tests__/ProjectDetailView.test.ts
+++ b/frontend/src/views/__tests__/ProjectDetailView.test.ts
@@ -378,4 +378,32 @@ describe('ProjectDetailView', () => {
     expect(wrapper.text()).toContain('Save the project to persist these changes.')
     expect(wrapper.text()).toContain("Entity 'method', row 1, column 'method_id': normalized '53' to 53 (int)")
   })
+
+  it('shows the target-model yaml tab for project-local target models', async () => {
+    mockProjectState.selectedProjectRef.value = {
+      metadata: { name: 'arbodat', target_model: '@include: target-model.yml' },
+      options: {},
+      entities: {},
+    }
+
+    const wrapper = mountProjectDetailView()
+
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Target Model')
+  })
+
+  it('hides the target-model yaml tab for shared target models', async () => {
+    mockProjectState.selectedProjectRef.value = {
+      metadata: { name: 'arbodat', target_model: '@include: resources/target_models/sead_superset_model.yml' },
+      options: {},
+      entities: {},
+    }
+
+    const wrapper = mountProjectDetailView()
+
+    await flushPromises()
+
+    expect(wrapper.text()).not.toContain('Target Model')
+  })
 })

--- a/resources/target_models/sead_superset_model.yml
+++ b/resources/target_models/sead_superset_model.yml
@@ -1,5 +1,6 @@
 model:
   name: SEAD Clearinghouse Extended
+  format_version: "1"
   version: 2.1.0
   description: SEAD archaeological research data model with enhanced spatial, dating, and metadata coverage
 
@@ -2166,6 +2167,57 @@ entities:
       - entity: ecocode_definition
         required: true
       - entity: taxa_tree_master
+        required: true
+
+  taxonomic_order_system:
+    role: lookup
+    required: false
+    description: Controlled system used to define taxonomic ordering codes.
+    domains: [taxonomy]
+    target_table: tbl_taxonomic_order_systems
+    public_id: taxonomic_order_system_id
+    identity_columns: [system_name]
+    columns:
+      system_name:
+        required: true
+        type: string
+        nullable: true
+      system_description:
+        type: string
+        nullable: true
+      taxonomic_order_system_uuid:
+        type: string
+        nullable: true
+    unique_sets:
+      - [system_name]
+
+  taxonomic_order:
+    role: fact
+    required: false
+    description: Taxonomic ordering code assigned to a taxon under a named order system.
+    aggregate_parent: taxa_tree_master
+    domains: [taxonomy]
+    target_table: tbl_taxonomic_order
+    public_id: taxonomic_order_id
+    identity_columns: [taxon_id, taxonomic_order_system_id, taxonomic_code]
+    columns:
+      taxon_id:
+        required: true
+        type: integer
+        nullable: false
+      taxonomic_order_system_id:
+        required: true
+        type: integer
+        nullable: false
+      taxonomic_code:
+        type: decimal
+        nullable: true
+    unique_sets:
+      - [taxon_id, taxonomic_order_system_id, taxonomic_code]
+    foreign_keys:
+      - entity: taxa_tree_master
+        required: true
+      - entity: taxonomic_order_system
         required: true
 
   # PHASE 1 ADDITIONS - Dating Domain

--- a/src/target_model/conformance.py
+++ b/src/target_model/conformance.py
@@ -111,6 +111,33 @@ class ForeignKeyConformanceValidator(EntityConformanceValidator):
         # for full bridge-aware logic. Keep this simple for backward compatibility.
         return []
 
+    def has_foreign_key_path(self, source_entity: str, target_entity: str, project: ShapeShiftProject) -> bool:
+        """Return whether the project FK graph reaches the target entity from the source entity."""
+        if source_entity == target_entity:
+            return True
+        if not project.has_table(source_entity) or not project.has_table(target_entity):
+            return False
+
+        visited: set[str] = {source_entity}
+        queue: list[str] = sorted(project.get_table(source_entity).get_target_facing_foreign_key_targets())
+
+        while queue:
+            current_entity = queue.pop(0)
+            if current_entity in visited:
+                continue
+            if current_entity == target_entity:
+                return True
+            visited.add(current_entity)
+
+            if not project.has_table(current_entity):
+                continue
+
+            queue.extend(
+                sorted(project.get_table(current_entity).get_target_facing_foreign_key_targets() - visited)
+            )
+
+        return False
+
     def validate(self, target_model: TargetModel, project: ShapeShiftProject) -> list[ConformanceIssue]:
         """Validate FK targets with bridge entity support (requires project access)."""
         issues: list[ConformanceIssue] = []
@@ -128,7 +155,7 @@ class ForeignKeyConformanceValidator(EntityConformanceValidator):
 
                 # Direct FK target (no bridge)
                 if not foreign_key.via:
-                    if foreign_key.entity not in project_targets:
+                    if foreign_key.entity not in project_targets and not self.has_foreign_key_path(entity_name, foreign_key.entity, project):
                         issues.append(
                             ConformanceIssue(
                                 code="MISSING_REQUIRED_FOREIGN_KEY_TARGET",

--- a/src/target_model/conformance.py
+++ b/src/target_model/conformance.py
@@ -85,6 +85,36 @@ def has_target_facing_foreign_key_path(source_entity: str, target_entity: str, p
     return False
 
 
+def get_append_column_rename_map(parent_table_cfg: TableConfig, append_table_cfg: TableConfig) -> dict[str, str]:
+    """Return the static column rename map applied to an append branch, if any."""
+    column_mapping = append_table_cfg.entity_cfg.get("column_mapping")
+    if isinstance(column_mapping, dict):
+        return {src: tgt for src, tgt in column_mapping.items() if isinstance(src, str) and isinstance(tgt, str)}
+
+    if not append_table_cfg.entity_cfg.get("align_by_position", False):
+        return {}
+
+    parent_columns = [
+        column for column in parent_table_cfg.columns if column not in {parent_table_cfg.system_id, parent_table_cfg.public_id}
+    ]
+    source_columns = [
+        column
+        for column in append_table_cfg.columns
+        if column not in {append_table_cfg.system_id, append_table_cfg.public_id, append_table_cfg.get_source_public_id()}
+    ]
+
+    if len(parent_columns) != len(source_columns):
+        return {}
+
+    return dict(zip(source_columns, parent_columns))
+
+
+def get_effective_append_target_facing_columns(parent_table_cfg: TableConfig, append_table_cfg: TableConfig) -> set[str]:
+    """Return the append branch's target-facing columns after static append renaming is applied."""
+    rename_map = get_append_column_rename_map(parent_table_cfg, append_table_cfg)
+    return {rename_map.get(column, column) for column in append_table_cfg.get_target_facing_columns()}
+
+
 @CONFORMANCE_VALIDATORS.register(key="public_id")
 class PublicIdConformanceValidator(EntityConformanceValidator):
 
@@ -239,6 +269,41 @@ class NoOrphanFactsConformanceValidator(ConformanceValidator):
                     entity=entity_name,
                 )
             )
+
+        return issues
+
+
+@CONFORMANCE_VALIDATORS.register(key="schema_aware_append")
+class SchemaAwareAppendConformanceValidator(EntityConformanceValidator):
+    """Append branches must also satisfy the target-model column contract for their parent entity."""
+
+    def guard(self, target_model: TargetModel, project: ShapeShiftProject, entity_name) -> bool:
+        return project.has_table(entity_name) and project.get_table(entity_name).has_append
+
+    def validate_entity(self, entity_name: str, entity_spec: EntitySpec, table_cfg: TableConfig) -> list[ConformanceIssue]:
+        issues: list[ConformanceIssue] = []
+        parent_columns = set(table_cfg.get_target_facing_columns())
+        required_columns = {
+            column_name for column_name, column_spec in entity_spec.columns.items() if column_spec.required and column_name in parent_columns
+        }
+        if not required_columns:
+            return issues
+
+        for append_index, append_table_cfg in enumerate(list(table_cfg.get_sub_table_configs())[1:], start=1):
+            effective_columns = get_effective_append_target_facing_columns(table_cfg, append_table_cfg)
+            missing_columns = sorted(required_columns - effective_columns)
+
+            for column_name in missing_columns:
+                issues.append(
+                    ConformanceIssue(
+                        code="APPEND_MISSING_REQUIRED_COLUMN",
+                        field=f"append[{append_index - 1}]",
+                        message=(
+                            f"Entity '{entity_name}' append item #{append_index} does not provide required target column '{column_name}'"
+                        ),
+                        entity=entity_name,
+                    )
+                )
 
         return issues
 

--- a/src/target_model/conformance.py
+++ b/src/target_model/conformance.py
@@ -343,9 +343,45 @@ class SourceTypeAppropriatenessConformanceValidator(EntityConformanceValidator):
 class TargetModelConformanceValidator(ConformanceValidator):
     """Validate a resolved Shape Shifter project against a target model."""
 
+    def get_disabled_rule_keys(self, project: ShapeShiftProject) -> set[str]:
+        """Read disabled conformance rule keys from project options."""
+        validation_options = project.options.get("validation", {}) or {}
+        raw_disabled_rules = validation_options.get("disabled_rules", [])
+
+        if raw_disabled_rules is None:
+            return set()
+        if isinstance(raw_disabled_rules, str):
+            return {raw_disabled_rules} if raw_disabled_rules else set()
+        if isinstance(raw_disabled_rules, (list, tuple, set)):
+            return {rule_key for rule_key in raw_disabled_rules if isinstance(rule_key, str) and rule_key}
+
+        return set()
+
+    def validate_disabled_rule_keys(self, disabled_rule_keys: set[str]) -> list[ConformanceIssue]:
+        """Return warning issues for unknown disabled rule keys."""
+        known_rule_keys = set(CONFORMANCE_VALIDATORS.items.keys())
+        unknown_rule_keys = sorted(disabled_rule_keys - known_rule_keys)
+
+        return [
+            ConformanceIssue(
+                severity="warning",
+                code="UNKNOWN_DISABLED_CONFORMANCE_RULE",
+                field="options.validation.disabled_rules",
+                message=(
+                    f"Project disables unknown conformance rule '{rule_key}'. "
+                    "Remove it or use a registered conformance validator key."
+                ),
+            )
+            for rule_key in unknown_rule_keys
+        ]
+
     def validate(self, target_model: TargetModel, project: ShapeShiftProject) -> list[ConformanceIssue]:
-        issues: list[ConformanceIssue] = []
-        for validator_cls in CONFORMANCE_VALIDATORS.items.values():
+        disabled_rule_keys = self.get_disabled_rule_keys(project)
+        issues: list[ConformanceIssue] = self.validate_disabled_rule_keys(disabled_rule_keys)
+
+        for rule_key, validator_cls in CONFORMANCE_VALIDATORS.items.items():
+            if rule_key in disabled_rule_keys:
+                continue
             validator: ConformanceValidator = validator_cls()
             issues.extend(validator.validate(target_model, project))
         return issues

--- a/src/target_model/conformance.py
+++ b/src/target_model/conformance.py
@@ -59,6 +59,32 @@ class EntityConformanceValidator(ConformanceValidator):
         return issues
 
 
+def has_target_facing_foreign_key_path(source_entity: str, target_entity: str, project: ShapeShiftProject) -> bool:
+    """Return whether the project's target-facing FK graph reaches the target entity from the source entity."""
+    if source_entity == target_entity:
+        return True
+    if not project.has_table(source_entity) or not project.has_table(target_entity):
+        return False
+
+    visited: set[str] = {source_entity}
+    queue: list[str] = sorted(project.get_table(source_entity).get_target_facing_foreign_key_targets())
+
+    while queue:
+        current_entity = queue.pop(0)
+        if current_entity in visited:
+            continue
+        if current_entity == target_entity:
+            return True
+        visited.add(current_entity)
+
+        if not project.has_table(current_entity):
+            continue
+
+        queue.extend(sorted(project.get_table(current_entity).get_target_facing_foreign_key_targets() - visited))
+
+    return False
+
+
 @CONFORMANCE_VALIDATORS.register(key="public_id")
 class PublicIdConformanceValidator(EntityConformanceValidator):
 
@@ -111,33 +137,6 @@ class ForeignKeyConformanceValidator(EntityConformanceValidator):
         # for full bridge-aware logic. Keep this simple for backward compatibility.
         return []
 
-    def has_foreign_key_path(self, source_entity: str, target_entity: str, project: ShapeShiftProject) -> bool:
-        """Return whether the project FK graph reaches the target entity from the source entity."""
-        if source_entity == target_entity:
-            return True
-        if not project.has_table(source_entity) or not project.has_table(target_entity):
-            return False
-
-        visited: set[str] = {source_entity}
-        queue: list[str] = sorted(project.get_table(source_entity).get_target_facing_foreign_key_targets())
-
-        while queue:
-            current_entity = queue.pop(0)
-            if current_entity in visited:
-                continue
-            if current_entity == target_entity:
-                return True
-            visited.add(current_entity)
-
-            if not project.has_table(current_entity):
-                continue
-
-            queue.extend(
-                sorted(project.get_table(current_entity).get_target_facing_foreign_key_targets() - visited)
-            )
-
-        return False
-
     def validate(self, target_model: TargetModel, project: ShapeShiftProject) -> list[ConformanceIssue]:
         """Validate FK targets with bridge entity support (requires project access)."""
         issues: list[ConformanceIssue] = []
@@ -155,7 +154,7 @@ class ForeignKeyConformanceValidator(EntityConformanceValidator):
 
                 # Direct FK target (no bridge)
                 if not foreign_key.via:
-                    if foreign_key.entity not in project_targets and not self.has_foreign_key_path(entity_name, foreign_key.entity, project):
+                    if foreign_key.entity not in project_targets and not has_target_facing_foreign_key_path(entity_name, foreign_key.entity, project):
                         issues.append(
                             ConformanceIssue(
                                 code="MISSING_REQUIRED_FOREIGN_KEY_TARGET",
@@ -199,6 +198,47 @@ class ForeignKeyConformanceValidator(EntityConformanceValidator):
                             entity=bridge_name,
                         )
                     )
+
+        return issues
+
+
+@CONFORMANCE_VALIDATORS.register(key="no_orphan_facts")
+class NoOrphanFactsConformanceValidator(ConformanceValidator):
+    """Fact entities must reach at least one required lookup or classifier when the constraint is declared."""
+
+    PARENT_ROLES: frozenset[str] = frozenset({"lookup", "classifier"})
+
+    def validate(self, target_model: TargetModel, project: ShapeShiftProject) -> list[ConformanceIssue]:
+        constraint_types = {constraint.type for constraint in target_model.constraints}
+        if "no_orphan_facts" not in constraint_types:
+            return []
+
+        parent_entities = {
+            entity_name
+            for entity_name, entity_spec in target_model.entities.items()
+            if entity_spec.role in self.PARENT_ROLES
+        }
+        if not parent_entities:
+            return []
+
+        issues: list[ConformanceIssue] = []
+        for entity_name, entity_spec in target_model.entities.items():
+            if entity_spec.role != "fact" or not project.has_table(entity_name):
+                continue
+
+            if any(has_target_facing_foreign_key_path(entity_name, parent_entity, project) for parent_entity in parent_entities):
+                continue
+
+            issues.append(
+                ConformanceIssue(
+                    code="ORPHAN_FACT_ENTITY",
+                    message=(
+                        f"Fact entity '{entity_name}' does not reach any lookup or classifier entity "
+                        f"declared by the target model ({', '.join(sorted(parent_entities))})"
+                    ),
+                    entity=entity_name,
+                )
+            )
 
         return issues
 

--- a/src/target_model/conformance.py
+++ b/src/target_model/conformance.py
@@ -63,6 +63,17 @@ class EntityConformanceValidator(ConformanceValidator):
         return issues
 
 
+class GlobalConformanceValidator(ConformanceValidator):
+    """Base type for validators that inspect the whole target model or project graph."""
+
+    @abstractmethod
+    def validate_global(self, target_model: TargetModel, project: ShapeShiftProject) -> list[ConformanceIssue]:
+        """Validate project-wide or cross-entity rules."""
+
+    def validate(self, target_model: TargetModel, project: ShapeShiftProject) -> list[ConformanceIssue]:
+        return self.validate_global(target_model, project)
+
+
 def has_target_facing_foreign_key_path(source_entity: str, target_entity: str, project: ShapeShiftProject) -> bool:
     """Return whether the project's target-facing FK graph reaches the target entity from the source entity."""
     if source_entity == target_entity:
@@ -237,7 +248,7 @@ class ForeignKeyConformanceValidator(EntityConformanceValidator):
 
 
 @CONFORMANCE_VALIDATORS.register(key="no_orphan_facts")
-class NoOrphanFactsConformanceValidator(ConformanceValidator):
+class NoOrphanFactsConformanceValidator(GlobalConformanceValidator):
     """Fact entities must reach at least one required lookup or classifier when the constraint is declared."""
 
     PARENT_ROLES: frozenset[str] = frozenset({"lookup", "classifier"})
@@ -253,7 +264,7 @@ class NoOrphanFactsConformanceValidator(ConformanceValidator):
         """Return the declared orphan-fact constraint, if present."""
         return next((constraint for constraint in target_model.constraints if constraint.type == "no_orphan_facts"), None)
 
-    def validate(self, target_model: TargetModel, project: ShapeShiftProject) -> list[ConformanceIssue]:
+    def validate_global(self, target_model: TargetModel, project: ShapeShiftProject) -> list[ConformanceIssue]:
         if self.get_constraint(target_model) is None:
             return []
 
@@ -343,9 +354,9 @@ class RequiredColumnsConformanceValidator(EntityConformanceValidator):
 
 
 @CONFORMANCE_VALIDATORS.register(key="required_entity")
-class RequiredEntityConformanceValidator(ConformanceValidator):
+class RequiredEntityConformanceValidator(GlobalConformanceValidator):
 
-    def validate(self, target_model: TargetModel, project: ShapeShiftProject) -> list[ConformanceIssue]:
+    def validate_global(self, target_model: TargetModel, project: ShapeShiftProject) -> list[ConformanceIssue]:
         issues: list[ConformanceIssue] = []
         for entity_name, entity_spec in target_model.entities.items():
             if not project.has_table(entity_name) and entity_spec.required:
@@ -360,10 +371,10 @@ class RequiredEntityConformanceValidator(ConformanceValidator):
 
 
 @CONFORMANCE_VALIDATORS.register(key="naming_convention")
-class NamingConventionConformanceValidator(ConformanceValidator):
+class NamingConventionConformanceValidator(GlobalConformanceValidator):
     """Validate that project entity public_id values conform to the target model naming conventions."""
 
-    def validate(self, target_model: TargetModel, project: ShapeShiftProject) -> list[ConformanceIssue]:
+    def validate_global(self, target_model: TargetModel, project: ShapeShiftProject) -> list[ConformanceIssue]:
         if not target_model.naming or not target_model.naming.public_id_suffix:
             return []
 
@@ -392,7 +403,7 @@ class NamingConventionConformanceValidator(ConformanceValidator):
 
 
 @CONFORMANCE_VALIDATORS.register(key="induced_requirements")
-class InducedRequirementConformanceValidator(ConformanceValidator):
+class InducedRequirementConformanceValidator(GlobalConformanceValidator):
     """If entity X is present in the project and has a required FK to Y, then Y is required — transitively.
 
     Uses BFS (Breadth-First Search) over the required-FK graph starting from all present,
@@ -403,7 +414,7 @@ class InducedRequirementConformanceValidator(ConformanceValidator):
     Example: X (present) → Y (absent) → Z (absent).  Both Y and Z are reported.
     """
 
-    def validate(self, target_model: TargetModel, project: ShapeShiftProject) -> list[ConformanceIssue]:
+    def validate_global(self, target_model: TargetModel, project: ShapeShiftProject) -> list[ConformanceIssue]:
         """Validate that if entity X is present and has a required FK to Y, then Y is also present (transitively)."""
 
         # Seed the queue with every present, non-globally-required entity.

--- a/src/target_model/conformance.py
+++ b/src/target_model/conformance.py
@@ -284,7 +284,9 @@ class SchemaAwareAppendConformanceValidator(EntityConformanceValidator):
         issues: list[ConformanceIssue] = []
         parent_columns = set(table_cfg.get_target_facing_columns())
         required_columns = {
-            column_name for column_name, column_spec in entity_spec.columns.items() if column_spec.required and column_name in parent_columns
+            column_name
+            for column_name, column_spec in entity_spec.columns.items()
+            if column_spec.required and not column_spec.generated and column_name in parent_columns
         }
         if not required_columns:
             return issues
@@ -315,7 +317,7 @@ class RequiredColumnsConformanceValidator(EntityConformanceValidator):
         issues: list[ConformanceIssue] = []
         declared_columns: set[str] = set(table_cfg.get_target_facing_columns())
         for column_name, column_spec in entity_spec.columns.items():
-            if column_spec.required and column_name not in declared_columns:
+            if column_spec.required and not column_spec.generated and column_name not in declared_columns:
                 issues.append(
                     ConformanceIssue(
                         code="MISSING_REQUIRED_COLUMN",

--- a/src/target_model/conformance.py
+++ b/src/target_model/conformance.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 
 from src.issues import CoreIssue
 from src.model import ShapeShiftProject, TableConfig
-from src.target_model.models import EntitySpec, TargetModel
+from src.target_model.models import EntitySpec, GlobalConstraint, SeverityLevel, TargetModel
 from src.utility import Registry
 
 
@@ -23,6 +23,10 @@ class ConformanceIssue(CoreIssue):
 
 
 class ConformanceValidator(ABC):
+
+    def get_default_severity(self, target_model: TargetModel, project: ShapeShiftProject) -> SeverityLevel:  # pylint: disable=unused-argument
+        """Return the default severity for issues emitted by this validator."""
+        return "error"
 
     @abstractmethod
     def validate(self, target_model: TargetModel, project: ShapeShiftProject) -> list[ConformanceIssue]:
@@ -238,9 +242,19 @@ class NoOrphanFactsConformanceValidator(ConformanceValidator):
 
     PARENT_ROLES: frozenset[str] = frozenset({"lookup", "classifier"})
 
+    def get_default_severity(self, target_model: TargetModel, project: ShapeShiftProject) -> SeverityLevel:  # pylint: disable=unused-argument
+        constraint = self.get_constraint(target_model)
+        if constraint and constraint.required in {True, "strict"}:
+            return "error"
+        return "warning"
+
+    @staticmethod
+    def get_constraint(target_model: TargetModel) -> GlobalConstraint | None:
+        """Return the declared orphan-fact constraint, if present."""
+        return next((constraint for constraint in target_model.constraints if constraint.type == "no_orphan_facts"), None)
+
     def validate(self, target_model: TargetModel, project: ShapeShiftProject) -> list[ConformanceIssue]:
-        constraint_types = {constraint.type for constraint in target_model.constraints}
-        if "no_orphan_facts" not in constraint_types:
+        if self.get_constraint(target_model) is None:
             return []
 
         parent_entities = {
@@ -457,6 +471,9 @@ class SourceTypeAppropriatenessConformanceValidator(EntityConformanceValidator):
 
     ALLOWED_TYPES: frozenset[str] = frozenset({"fixed", "sql"})
 
+    def get_default_severity(self, target_model: TargetModel, project: ShapeShiftProject) -> SeverityLevel:  # pylint: disable=unused-argument
+        return "warning"
+
     def validate_entity(self, entity_name: str, entity_spec: EntitySpec, table_cfg: TableConfig) -> list[ConformanceIssue]:
         if entity_spec.role != "classifier":
             return []
@@ -477,9 +494,17 @@ class SourceTypeAppropriatenessConformanceValidator(EntityConformanceValidator):
 class TargetModelConformanceValidator(ConformanceValidator):
     """Validate a resolved Shape Shifter project against a target model."""
 
+    VALID_SEVERITIES: frozenset[str] = frozenset({"error", "warning", "info"})
+
+    @staticmethod
+    def get_validation_options(project: ShapeShiftProject) -> dict:
+        """Return the project's validation options as a dict."""
+        validation_options = project.options.get("validation", {}) or {}
+        return validation_options if isinstance(validation_options, dict) else {}
+
     def get_disabled_rule_keys(self, project: ShapeShiftProject) -> set[str]:
         """Read disabled conformance rule keys from project options."""
-        validation_options = project.options.get("validation", {}) or {}
+        validation_options = self.get_validation_options(project)
         raw_disabled_rules = validation_options.get("disabled_rules", [])
 
         if raw_disabled_rules is None:
@@ -490,6 +515,20 @@ class TargetModelConformanceValidator(ConformanceValidator):
             return {rule_key for rule_key in raw_disabled_rules if isinstance(rule_key, str) and rule_key}
 
         return set()
+
+    def get_severity_overrides(self, project: ShapeShiftProject) -> dict[str, str]:
+        """Read conformance severity overrides keyed by validator registry key."""
+        validation_options = self.get_validation_options(project)
+        raw_severity_overrides = validation_options.get("severity_overrides", {})
+
+        if not isinstance(raw_severity_overrides, dict):
+            return {}
+
+        return {
+            rule_key: severity
+            for rule_key, severity in raw_severity_overrides.items()
+            if isinstance(rule_key, str) and rule_key and isinstance(severity, str) and severity
+        }
 
     def validate_disabled_rule_keys(self, disabled_rule_keys: set[str]) -> list[ConformanceIssue]:
         """Return warning issues for unknown disabled rule keys."""
@@ -509,13 +548,69 @@ class TargetModelConformanceValidator(ConformanceValidator):
             for rule_key in unknown_rule_keys
         ]
 
+    def validate_severity_overrides(self, severity_overrides: dict[str, str]) -> list[ConformanceIssue]:
+        """Return warning issues for unknown or invalid severity overrides."""
+        known_rule_keys = set(CONFORMANCE_VALIDATORS.items.keys())
+        issues: list[ConformanceIssue] = []
+
+        for rule_key in sorted(severity_overrides):
+            if rule_key not in known_rule_keys:
+                issues.append(
+                    ConformanceIssue(
+                        severity="warning",
+                        code="UNKNOWN_CONFORMANCE_SEVERITY_OVERRIDE",
+                        field="options.validation.severity_overrides",
+                        message=(
+                            f"Project overrides severity for unknown conformance rule '{rule_key}'. "
+                            "Remove it or use a registered conformance validator key."
+                        ),
+                    )
+                )
+
+        for rule_key, severity in sorted(severity_overrides.items()):
+            if severity in self.VALID_SEVERITIES:
+                continue
+            issues.append(
+                ConformanceIssue(
+                    severity="warning",
+                    code="INVALID_CONFORMANCE_SEVERITY_OVERRIDE",
+                    field=f"options.validation.severity_overrides.{rule_key}",
+                    message=(
+                        f"Project overrides conformance rule '{rule_key}' with unsupported severity '{severity}'. "
+                        "Use one of: error, warning, info."
+                    ),
+                )
+            )
+
+        return issues
+
+    def resolve_rule_severity(
+        self,
+        rule_key: str,
+        validator: ConformanceValidator,
+        target_model: TargetModel,
+        project: ShapeShiftProject,
+        severity_overrides: dict[str, str],
+    ) -> SeverityLevel:
+        """Resolve the effective severity for a registered conformance rule."""
+        override = severity_overrides.get(rule_key)
+        if override in self.VALID_SEVERITIES:
+            return override  # type: ignore[return-value]
+        return validator.get_default_severity(target_model, project)
+
     def validate(self, target_model: TargetModel, project: ShapeShiftProject) -> list[ConformanceIssue]:
         disabled_rule_keys = self.get_disabled_rule_keys(project)
+        severity_overrides = self.get_severity_overrides(project)
         issues: list[ConformanceIssue] = self.validate_disabled_rule_keys(disabled_rule_keys)
+        issues.extend(self.validate_severity_overrides(severity_overrides))
 
         for rule_key, validator_cls in CONFORMANCE_VALIDATORS.items.items():
             if rule_key in disabled_rule_keys:
                 continue
             validator: ConformanceValidator = validator_cls()
-            issues.extend(validator.validate(target_model, project))
+            issue_severity = self.resolve_rule_severity(rule_key, validator, target_model, project, severity_overrides)
+            rule_issues = validator.validate(target_model, project)
+            for issue in rule_issues:
+                issue.severity = issue_severity
+            issues.extend(rule_issues)
         return issues

--- a/src/target_model/data_validators.py
+++ b/src/target_model/data_validators.py
@@ -128,6 +128,54 @@ class TypeCompatibilityConformanceValidator:
         return issues
 
 
+class AllowedValuesConformanceValidator:
+    """Columns with allowed_values must only contain values declared by the target model."""
+
+    @staticmethod
+    def validate(df: pd.DataFrame, entity_spec: EntitySpec, entity_name: str) -> list[ValidationIssue]:
+        """Check that produced values stay within the declared allowed_values set.
+
+        Columns absent from the DataFrame are skipped because structural conformance covers them.
+        Null values are ignored here and remain the responsibility of nullability checks.
+        """
+        if df.empty:
+            return []
+
+        issues: list[ValidationIssue] = []
+        for col_name, col_spec in entity_spec.columns.items():
+            if not col_spec.allowed_values or col_name not in df.columns:
+                continue
+
+            non_null_values = df[col_name].dropna()
+            if non_null_values.empty:
+                continue
+
+            invalid_values = sorted({value for value in non_null_values.unique().tolist() if value not in col_spec.allowed_values}, key=str)
+            if not invalid_values:
+                continue
+
+            sample = ", ".join(str(value) for value in invalid_values[:5])
+            issues.append(
+                ValidationIssue(
+                    severity="error",
+                    entity=entity_name,
+                    field=col_name,
+                    message=(
+                        f"Column '{col_name}' in entity '{entity_name}' contains values outside the declared allowed_values set"
+                    ),
+                    code="VALUE_NOT_IN_ALLOWED_SET",
+                    suggestion=(
+                        f"Update the mapping or target model so '{col_name}' only contains allowed values. Sample unexpected values: {sample}"
+                    ),
+                    category="conformance",
+                    priority="high",
+                    auto_fixable=False,
+                )
+            )
+
+        return issues
+
+
 class FKReferentialIntegrityConformanceValidator:
     """FK values in produced data must exist in the parent entity's output.
 

--- a/src/target_model/models.py
+++ b/src/target_model/models.py
@@ -17,6 +17,7 @@ class ColumnSpec(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     required: bool = False
+    generated: bool = False
     type: str | None = None
     nullable: bool | None = None
     description: str | None = None

--- a/src/target_model/models.py
+++ b/src/target_model/models.py
@@ -5,6 +5,9 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Field
 
 
+SeverityLevel = Literal["error", "warning", "info"]
+
+
 class ForeignKeySpec(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -54,6 +57,7 @@ class GlobalConstraint(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     type: str
+    required: bool | Literal["strict"] | None = None
 
 
 class ModelMetadata(BaseModel):

--- a/src/target_model/models.py
+++ b/src/target_model/models.py
@@ -58,6 +58,7 @@ class ModelMetadata(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     name: str
+    format_version: str = "1"
     version: str
     description: str | None = None
 

--- a/src/target_model/models.py
+++ b/src/target_model/models.py
@@ -18,6 +18,7 @@ class ColumnSpec(BaseModel):
 
     required: bool = False
     generated: bool = False
+    allowed_values: list[str | int | float | bool] = Field(default_factory=list)
     type: str | None = None
     nullable: bool | None = None
     description: str | None = None

--- a/src/target_model/spec_validator.py
+++ b/src/target_model/spec_validator.py
@@ -67,6 +67,32 @@ class TargetModelSpecValidator:
                             )
                         )
 
+            for column_name, column_spec in entity_spec.columns.items():
+                if column_spec.allowed_values and column_spec.type not in {None, "enum"}:
+                    issues.append(
+                        SpecValidationIssue(
+                            code="ALLOWED_VALUES_REQUIRE_ENUM_TYPE",
+                            message=(
+                                f"Entity '{entity_name}' column '{column_name}' declares allowed_values but uses type "
+                                f"'{column_spec.type}' instead of 'enum'"
+                            ),
+                            entity=entity_name,
+                            field=column_name,
+                        )
+                    )
+
+                if column_spec.type == "enum" and not column_spec.allowed_values:
+                    issues.append(
+                        SpecValidationIssue(
+                            code="ENUM_MISSING_ALLOWED_VALUES",
+                            message=(
+                                f"Entity '{entity_name}' column '{column_name}' uses type 'enum' but does not declare allowed_values"
+                            ),
+                            entity=entity_name,
+                            field=column_name,
+                        )
+                    )
+
             issues.extend(self._validate_aggregate_parent(target_model, entity_name, entity_spec))
             issues.extend(self._validate_identity_rules(entity_name, entity_spec))
 

--- a/tests/model/test_target_model_conformance.py
+++ b/tests/model/test_target_model_conformance.py
@@ -432,8 +432,10 @@ def _minimal_target_model(entities: dict) -> TargetModel:
     return TargetModel.model_validate({"model": {"name": "test", "version": "1.0"}, "entities": entities})
 
 
-def _minimal_project(entities: dict) -> ShapeShiftProject:
-    return ShapeShiftProject(cfg={"metadata": {"name": "test", "type": "shapeshifter-project"}, "entities": entities})
+def _minimal_project(entities: dict, options: dict | None = None) -> ShapeShiftProject:
+    return ShapeShiftProject(
+        cfg={"metadata": {"name": "test", "type": "shapeshifter-project"}, "entities": entities, "options": options or {}}
+    )
 
 
 def test_public_id_validator_produces_missing_public_id_when_project_entity_has_none() -> None:
@@ -456,6 +458,25 @@ def test_public_id_validator_is_silent_when_spec_declares_no_public_id() -> None
     issues: list[ConformanceIssue] = TargetModelConformanceValidator().validate(target_model, project)
 
     assert not any(issue.code.startswith("MISSING_PUBLIC_ID") or issue.code.startswith("UNEXPECTED_PUBLIC_ID") for issue in issues)
+
+
+def test_disabled_rules_skip_named_conformance_validator() -> None:
+    """Disabled conformance rules should be skipped by registry key."""
+    target_model: TargetModel = TargetModel.model_validate(
+        {
+            "model": {"name": "test", "version": "1.0"},
+            "naming": {"public_id_suffix": "_id"},
+            "entities": {"location": {}},
+        }
+    )
+    project: ShapeShiftProject = _minimal_project(
+        {"location": {"public_id": "location_identifier", "columns": ["location_name"]}},
+        options={"validation": {"disabled_rules": ["naming_convention"]}},
+    )
+
+    codes: list[str] = [issue.code for issue in TargetModelConformanceValidator().validate(target_model, project)]
+
+    assert "PUBLIC_ID_NAMING_VIOLATION" not in codes
 
 
 # ---------------------------------------------------------------------------

--- a/tests/model/test_target_model_conformance.py
+++ b/tests/model/test_target_model_conformance.py
@@ -314,6 +314,55 @@ def test_core_conformance_accepts_sample_group_note_example_fixture() -> None:
     assert issue_pairs(target_model, project) == []
 
 
+def test_core_conformance_accepts_transitive_foreign_key_path() -> None:
+    target_model: TargetModel = _minimal_target_model(
+        {
+            "site": {
+                "required": True,
+                "public_id": "site_id",
+            },
+            "sample_group": {
+                "required": True,
+                "public_id": "sample_group_id",
+                "foreign_keys": [{"entity": "site", "required": True}],
+            },
+            "sample": {
+                "required": True,
+                "public_id": "sample_id",
+                "foreign_keys": [{"entity": "site", "required": True}],
+            },
+        }
+    )
+    project = ShapeShiftProject(
+        cfg={
+            "metadata": {
+                "name": "transitive-fk-example",
+                "type": "shapeshifter-project",
+            },
+            "entities": {
+                "site": {
+                    "public_id": "site_id",
+                    "columns": ["site_name"],
+                },
+                "sample_group": {
+                    "public_id": "sample_group_id",
+                    "columns": ["sample_group_name"],
+                    "foreign_keys": [{"entity": "site", "local_keys": ["site_id"], "remote_keys": ["site_id"]}],
+                },
+                "sample": {
+                    "public_id": "sample_id",
+                    "columns": ["sample_name"],
+                    "foreign_keys": [{"entity": "sample_group", "local_keys": ["sample_group_id"], "remote_keys": ["sample_group_id"]}],
+                },
+            },
+        }
+    )
+
+    issues = set(issue_pairs(target_model, project))
+
+    assert ("MISSING_REQUIRED_FOREIGN_KEY_TARGET", "sample") not in issues
+
+
 def test_core_conformance_keeps_alias_like_names_strict() -> None:
     target_model: TargetModel = load_target_model()
     project = ShapeShiftProject(

--- a/tests/model/test_target_model_conformance.py
+++ b/tests/model/test_target_model_conformance.py
@@ -905,11 +905,29 @@ def test_no_orphan_facts_emits_issue_for_fact_without_required_lookup_path() -> 
     )
     project: ShapeShiftProject = _minimal_project({"analysis_entity": {"columns": ["analysis_name"]}, "dataset": {"columns": ["dataset_name"]}})
 
-    codes_entities: set[tuple[str, str | None]] = set(
-        (i.code, i.entity) for i in TargetModelConformanceValidator().validate(target_model, project)
-    )
+    issues = TargetModelConformanceValidator().validate(target_model, project)
 
-    assert ("ORPHAN_FACT_ENTITY", "analysis_entity") in codes_entities
+    assert any(issue.code == "ORPHAN_FACT_ENTITY" and issue.entity == "analysis_entity" for issue in issues)
+    assert next(issue for issue in issues if issue.code == "ORPHAN_FACT_ENTITY").severity == "warning"
+
+
+def test_no_orphan_facts_uses_error_severity_when_constraint_is_strict() -> None:
+    """Strict orphan-fact constraints should be promoted from warning to error."""
+    target_model: TargetModel = TargetModel.model_validate(
+        {
+            "model": {"name": "test", "version": "1.0"},
+            "constraints": [{"type": "no_orphan_facts", "required": "strict"}],
+            "entities": {
+                "dataset": {"role": "lookup", "required": True},
+                "analysis_entity": {"role": "fact", "required": True},
+            },
+        }
+    )
+    project: ShapeShiftProject = _minimal_project({"analysis_entity": {"columns": ["analysis_name"]}, "dataset": {"columns": ["dataset_name"]}})
+
+    issues = TargetModelConformanceValidator().validate(target_model, project)
+
+    assert any(issue.code == "ORPHAN_FACT_ENTITY" and issue.severity == "error" for issue in issues)
 
 
 def test_no_orphan_facts_accepts_transitive_required_lookup_path() -> None:
@@ -944,3 +962,48 @@ def test_no_orphan_facts_accepts_transitive_required_lookup_path() -> None:
     codes: list[str] = [i.code for i in TargetModelConformanceValidator().validate(target_model, project)]
 
     assert "ORPHAN_FACT_ENTITY" not in codes
+
+
+def test_source_type_appropriateness_emits_warning_by_default() -> None:
+    """Classifier source-type mismatches should stay advisory unless overridden."""
+    target_model: TargetModel = _minimal_target_model(
+        {
+            "taxon": {
+                "role": "classifier",
+                "required": True,
+            }
+        }
+    )
+    project: ShapeShiftProject = _minimal_project({"taxon": {"type": "entity", "columns": ["taxon_name"]}})
+
+    issues = TargetModelConformanceValidator().validate(target_model, project)
+
+    assert any(issue.code == "CLASSIFIER_WRONG_SOURCE_TYPE" and issue.severity == "warning" for issue in issues)
+
+
+def test_rule_severity_override_promotes_phase_four_rule_to_error() -> None:
+    """Project severity overrides should replace the default severity for a conformance rule."""
+    target_model: TargetModel = _minimal_target_model(
+        {
+            "taxon": {
+                "role": "classifier",
+                "required": True,
+            }
+        }
+    )
+    project: ShapeShiftProject = ShapeShiftProject(
+        cfg={
+            "metadata": {"name": "severity-override-example", "type": "shapeshifter-project"},
+            "entities": {
+                "taxon": {
+                    "type": "entity",
+                    "columns": ["taxon_name"],
+                }
+            },
+            "options": {"validation": {"severity_overrides": {"source_type_appropriateness": "error"}}},
+        }
+    )
+
+    issues = TargetModelConformanceValidator().validate(target_model, project)
+
+    assert any(issue.code == "CLASSIFIER_WRONG_SOURCE_TYPE" and issue.severity == "error" for issue in issues)

--- a/tests/model/test_target_model_conformance.py
+++ b/tests/model/test_target_model_conformance.py
@@ -432,6 +432,7 @@ def test_core_conformance_reports_known_gaps_for_full_arbodat_project() -> None:
     assert sorted(issue_pairs(target_model, project)) == sorted(
         [
             ("MISSING_INDUCED_REQUIRED_ENTITY", "taxa_tree_master"),
+            ("ORPHAN_FACT_ENTITY", "abundance_property"),
             ("MISSING_REQUIRED_COLUMN", "abundance_ident_level"),
             ("MISSING_REQUIRED_COLUMN", "analysis_entity"),
             ("MISSING_REQUIRED_FOREIGN_KEY_TARGET", "abundance"),
@@ -472,7 +473,12 @@ def test_core_conformance_current_corpus_issue_families_are_stable() -> None:
             }
         ),
         "arbodat_full": Counter(
-            {"MISSING_REQUIRED_FOREIGN_KEY_TARGET": 3, "MISSING_REQUIRED_COLUMN": 2, "MISSING_INDUCED_REQUIRED_ENTITY": 1}
+            {
+                "MISSING_REQUIRED_FOREIGN_KEY_TARGET": 3,
+                "MISSING_REQUIRED_COLUMN": 2,
+                "MISSING_INDUCED_REQUIRED_ENTITY": 1,
+                "ORPHAN_FACT_ENTITY": 1,
+            }
         ),
     }
 
@@ -731,3 +737,73 @@ def test_induced_requirement_transitive_stops_at_present_intermediate() -> None:
 
     assert ("MISSING_INDUCED_REQUIRED_ENTITY", "taxon_group") in codes_entities
     assert ("MISSING_INDUCED_REQUIRED_ENTITY", "taxon") not in codes_entities  # taxon is present
+
+
+def test_no_orphan_facts_is_silent_when_constraint_is_not_declared() -> None:
+    """The orphan-fact rule should only run when the target model declares that global constraint."""
+    target_model: TargetModel = _minimal_target_model(
+        {
+            "dataset": {"role": "lookup", "required": True},
+            "analysis_entity": {"role": "fact", "required": True},
+        }
+    )
+    project: ShapeShiftProject = _minimal_project({"analysis_entity": {"columns": ["analysis_name"]}, "dataset": {"columns": ["dataset_name"]}})
+
+    codes: list[str] = [i.code for i in TargetModelConformanceValidator().validate(target_model, project)]
+
+    assert "ORPHAN_FACT_ENTITY" not in codes
+
+
+def test_no_orphan_facts_emits_issue_for_fact_without_required_lookup_path() -> None:
+    """A fact with no path to any required lookup or classifier should be reported when the constraint is enabled."""
+    target_model: TargetModel = TargetModel.model_validate(
+        {
+            "model": {"name": "test", "version": "1.0"},
+            "constraints": [{"type": "no_orphan_facts"}],
+            "entities": {
+                "dataset": {"role": "lookup", "required": True},
+                "analysis_entity": {"role": "fact", "required": True},
+            },
+        }
+    )
+    project: ShapeShiftProject = _minimal_project({"analysis_entity": {"columns": ["analysis_name"]}, "dataset": {"columns": ["dataset_name"]}})
+
+    codes_entities: set[tuple[str, str | None]] = set(
+        (i.code, i.entity) for i in TargetModelConformanceValidator().validate(target_model, project)
+    )
+
+    assert ("ORPHAN_FACT_ENTITY", "analysis_entity") in codes_entities
+
+
+def test_no_orphan_facts_accepts_transitive_required_lookup_path() -> None:
+    """A fact linked transitively to a required lookup should satisfy the orphan-fact rule."""
+    target_model: TargetModel = TargetModel.model_validate(
+        {
+            "model": {"name": "test", "version": "1.0"},
+            "constraints": [{"type": "no_orphan_facts"}],
+            "entities": {
+                "site": {"role": "lookup", "required": True},
+                "sample_group": {"role": "bridge", "required": True},
+                "sample": {"role": "fact", "required": True},
+            },
+        }
+    )
+    project: ShapeShiftProject = _minimal_project(
+        {
+            "site": {"public_id": "site_id", "columns": ["site_name"]},
+            "sample_group": {
+                "public_id": "sample_group_id",
+                "columns": ["sample_group_name"],
+                "foreign_keys": [{"entity": "site", "local_keys": ["site_id"], "remote_keys": ["site_id"]}],
+            },
+            "sample": {
+                "public_id": "sample_id",
+                "columns": ["sample_name"],
+                "foreign_keys": [{"entity": "sample_group", "local_keys": ["sample_group_id"], "remote_keys": ["sample_group_id"]}],
+            },
+        }
+    )
+
+    codes: list[str] = [i.code for i in TargetModelConformanceValidator().validate(target_model, project)]
+
+    assert "ORPHAN_FACT_ENTITY" not in codes

--- a/tests/model/test_target_model_conformance.py
+++ b/tests/model/test_target_model_conformance.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import yaml
 
 from src.model import ShapeShiftProject, TableConfig
-from src.target_model.conformance import ConformanceIssue, TargetModelConformanceValidator
+from src.target_model.conformance import CONFORMANCE_VALIDATORS, ConformanceIssue, EntityConformanceValidator, GlobalConformanceValidator, TargetModelConformanceValidator
 from src.target_model.models import TargetModel
 
 TEST_DATA_DIR: Path = Path(__file__).resolve().parent.parent / "test_data"
@@ -30,6 +30,44 @@ def load_real_project(project_name: str) -> ShapeShiftProject:
 def issue_pairs(target_model: TargetModel, project: ShapeShiftProject) -> list[tuple[str, str | None]]:
     issues: list[ConformanceIssue] = TargetModelConformanceValidator().validate(target_model, project)
     return [(issue.code, issue.entity) for issue in issues]
+
+
+def test_conformance_registry_runs_global_and_entity_validator_base_types() -> None:
+    """The registry should execute both global and entity validator subclasses."""
+
+    @CONFORMANCE_VALIDATORS.register(key="test_global_conformance_validator")
+    class TestGlobalConformanceValidator(GlobalConformanceValidator):
+        def validate_global(self, target_model: TargetModel, project: ShapeShiftProject) -> list[ConformanceIssue]:
+            return [ConformanceIssue(code="TEST_GLOBAL_CONFORMANCE_RULE", entity="sample", message="global validator executed")]
+
+    @CONFORMANCE_VALIDATORS.register(key="test_entity_conformance_validator")
+    class TestEntityConformanceValidator(EntityConformanceValidator):
+        def validate_entity(self, entity_name: str, entity_spec, table_cfg) -> list[ConformanceIssue]:
+            return [ConformanceIssue(code="TEST_ENTITY_CONFORMANCE_RULE", entity=entity_name, message="entity validator executed")]
+
+    target_model = TargetModel.model_validate(
+        {
+            "model": {"name": "test", "version": "1.0"},
+            "entities": {"sample": {"required": True, "public_id": "sample_id"}},
+        }
+    )
+    project = ShapeShiftProject(
+        cfg={
+            "metadata": {"name": "registry-base-types", "type": "shapeshifter-project"},
+            "entities": {"sample": {"public_id": "sample_id", "columns": ["sample_name"]}},
+        }
+    )
+
+    try:
+        issues = TargetModelConformanceValidator().validate(target_model, project)
+    finally:
+        CONFORMANCE_VALIDATORS.items.pop("test_global_conformance_validator", None)
+        CONFORMANCE_VALIDATORS.items.pop("test_entity_conformance_validator", None)
+
+    issue_codes = {issue.code for issue in issues}
+
+    assert "TEST_GLOBAL_CONFORMANCE_RULE" in issue_codes
+    assert "TEST_ENTITY_CONFORMANCE_RULE" in issue_codes
 
 
 def test_table_config_target_facing_columns_treat_materialized_entity_as_fixed_view() -> None:

--- a/tests/model/test_target_model_conformance.py
+++ b/tests/model/test_target_model_conformance.py
@@ -363,6 +363,83 @@ def test_core_conformance_accepts_transitive_foreign_key_path() -> None:
     assert ("MISSING_REQUIRED_FOREIGN_KEY_TARGET", "sample") not in issues
 
 
+def test_schema_aware_append_emits_issue_when_append_branch_misses_required_column() -> None:
+    target_model: TargetModel = _minimal_target_model(
+        {
+            "site": {
+                "required": True,
+                "public_id": "site_id",
+                "columns": {
+                    "site_name": {"required": True},
+                    "site_type": {"required": True},
+                },
+            }
+        }
+    )
+    project = ShapeShiftProject(
+        cfg={
+            "metadata": {"name": "append-missing-required", "type": "shapeshifter-project"},
+            "entities": {
+                "site": {
+                    "public_id": "site_id",
+                    "columns": ["site_name", "site_type"],
+                    "append": [
+                        {
+                            "type": "fixed",
+                            "columns": ["site_name"],
+                            "values": [["Append Site"]],
+                        }
+                    ],
+                }
+            },
+        }
+    )
+
+    issues = set(issue_pairs(target_model, project))
+
+    assert ("APPEND_MISSING_REQUIRED_COLUMN", "site") in issues
+
+
+def test_schema_aware_append_respects_align_by_position() -> None:
+    target_model: TargetModel = _minimal_target_model(
+        {
+            "site": {
+                "required": True,
+                "public_id": "site_id",
+                "columns": {
+                    "site_name": {"required": True},
+                    "site_type": {"required": True},
+                },
+            }
+        }
+    )
+    project = ShapeShiftProject(
+        cfg={
+            "metadata": {"name": "append-align-by-position", "type": "shapeshifter-project"},
+            "entities": {
+                "legacy_site": {
+                    "public_id": "legacy_site_id",
+                    "columns": ["legacy_name", "legacy_kind"],
+                },
+                "site": {
+                    "public_id": "site_id",
+                    "columns": ["site_name", "site_type"],
+                    "append": [
+                        {
+                            "source": "legacy_site",
+                            "align_by_position": True,
+                        }
+                    ],
+                },
+            },
+        }
+    )
+
+    codes = [issue.code for issue in TargetModelConformanceValidator().validate(target_model, project)]
+
+    assert "APPEND_MISSING_REQUIRED_COLUMN" not in codes
+
+
 def test_core_conformance_keeps_alias_like_names_strict() -> None:
     target_model: TargetModel = load_target_model()
     project = ShapeShiftProject(
@@ -431,6 +508,8 @@ def test_core_conformance_reports_known_gaps_for_full_arbodat_project() -> None:
 
     assert sorted(issue_pairs(target_model, project)) == sorted(
         [
+            ("APPEND_MISSING_REQUIRED_COLUMN", "analysis_entity"),
+            ("APPEND_MISSING_REQUIRED_COLUMN", "analysis_entity"),
             ("MISSING_INDUCED_REQUIRED_ENTITY", "taxa_tree_master"),
             ("ORPHAN_FACT_ENTITY", "abundance_property"),
             ("MISSING_REQUIRED_COLUMN", "abundance_ident_level"),
@@ -476,6 +555,7 @@ def test_core_conformance_current_corpus_issue_families_are_stable() -> None:
             {
                 "MISSING_REQUIRED_FOREIGN_KEY_TARGET": 3,
                 "MISSING_REQUIRED_COLUMN": 2,
+                "APPEND_MISSING_REQUIRED_COLUMN": 2,
                 "MISSING_INDUCED_REQUIRED_ENTITY": 1,
                 "ORPHAN_FACT_ENTITY": 1,
             }

--- a/tests/model/test_target_model_conformance.py
+++ b/tests/model/test_target_model_conformance.py
@@ -440,6 +440,63 @@ def test_schema_aware_append_respects_align_by_position() -> None:
     assert "APPEND_MISSING_REQUIRED_COLUMN" not in codes
 
 
+def test_required_columns_ignores_required_generated_columns() -> None:
+    target_model: TargetModel = _minimal_target_model(
+        {
+            "site": {
+                "required": True,
+                "public_id": "site_id",
+                "columns": {
+                    "site_name": {"required": True},
+                    "site_slug": {"required": True, "generated": True},
+                },
+            }
+        }
+    )
+    project = _minimal_project({"site": {"public_id": "site_id", "columns": ["site_name"]}})
+
+    issues = issue_pairs(target_model, project)
+
+    assert ("MISSING_REQUIRED_COLUMN", "site") not in issues
+
+
+def test_schema_aware_append_ignores_required_generated_columns() -> None:
+    target_model: TargetModel = _minimal_target_model(
+        {
+            "site": {
+                "required": True,
+                "public_id": "site_id",
+                "columns": {
+                    "site_name": {"required": True},
+                    "site_slug": {"required": True, "generated": True},
+                },
+            }
+        }
+    )
+    project = ShapeShiftProject(
+        cfg={
+            "metadata": {"name": "append-generated-column", "type": "shapeshifter-project"},
+            "entities": {
+                "site": {
+                    "public_id": "site_id",
+                    "columns": ["site_name", "site_slug"],
+                    "append": [
+                        {
+                            "type": "fixed",
+                            "columns": ["site_name"],
+                            "values": [["Append Site"]],
+                        }
+                    ],
+                }
+            },
+        }
+    )
+
+    codes = [issue.code for issue in TargetModelConformanceValidator().validate(target_model, project)]
+
+    assert "APPEND_MISSING_REQUIRED_COLUMN" not in codes
+
+
 def test_core_conformance_keeps_alias_like_names_strict() -> None:
     target_model: TargetModel = load_target_model()
     project = ShapeShiftProject(

--- a/tests/target_model/test_models.py
+++ b/tests/target_model/test_models.py
@@ -42,6 +42,7 @@ def test_target_model_parses_richer_entity_payload() -> None:
                     "columns": {
                         "location_name": {"required": True, "type": "string", "nullable": False},
                         "location_type_id": {"required": True, "generated": True, "type": "integer", "nullable": False},
+                        "location_kind": {"type": "enum", "allowed_values": ["site", "trench"]},
                     },
                     "unique_sets": [["location_type_id", "location_name"]],
                     "foreign_keys": [{"entity": "location_type", "required": True}],
@@ -59,9 +60,10 @@ def test_target_model_parses_richer_entity_payload() -> None:
     location = target_model.entities["location"]
     assert location.domains == ["core", "spatial"]
     assert location.identity_columns == ["location_type_id", "location_name"]
-    assert list(location.columns) == ["location_name", "location_type_id"]
+    assert list(location.columns) == ["location_name", "location_type_id", "location_kind"]
     assert location.columns["location_name"].required is True
     assert location.columns["location_type_id"].generated is True
+    assert location.columns["location_kind"].allowed_values == ["site", "trench"]
     assert location.unique_sets == [["location_type_id", "location_name"]]
 
 

--- a/tests/target_model/test_models.py
+++ b/tests/target_model/test_models.py
@@ -41,7 +41,7 @@ def test_target_model_parses_richer_entity_payload() -> None:
                     "identity_columns": ["location_type_id", "location_name"],
                     "columns": {
                         "location_name": {"required": True, "type": "string", "nullable": False},
-                        "location_type_id": {"required": True, "type": "integer", "nullable": False},
+                        "location_type_id": {"required": True, "generated": True, "type": "integer", "nullable": False},
                     },
                     "unique_sets": [["location_type_id", "location_name"]],
                     "foreign_keys": [{"entity": "location_type", "required": True}],
@@ -61,6 +61,7 @@ def test_target_model_parses_richer_entity_payload() -> None:
     assert location.identity_columns == ["location_type_id", "location_name"]
     assert list(location.columns) == ["location_name", "location_type_id"]
     assert location.columns["location_name"].required is True
+    assert location.columns["location_type_id"].generated is True
     assert location.unique_sets == [["location_type_id", "location_name"]]
 
 

--- a/tests/target_model/test_models.py
+++ b/tests/target_model/test_models.py
@@ -101,3 +101,18 @@ def test_target_model_round_trip_preserves_format_version() -> None:
     round_tripped = TargetModel.model_validate(target_model.model_dump(mode="json"))
 
     assert round_tripped == target_model
+
+
+def test_target_model_constraint_parses_strict_required_mode() -> None:
+    target_model = TargetModel.model_validate(
+        {
+            "model": {
+                "name": "SEAD Clearinghouse",
+                "version": "2.0.0",
+            },
+            "constraints": [{"type": "no_orphan_facts", "required": "strict"}],
+        }
+    )
+
+    assert target_model.constraints[0].type == "no_orphan_facts"
+    assert target_model.constraints[0].required == "strict"

--- a/tests/target_model/test_models.py
+++ b/tests/target_model/test_models.py
@@ -1,3 +1,7 @@
+import pytest
+
+from pydantic import ValidationError
+
 from src.target_model.models import TargetModel
 
 
@@ -14,6 +18,7 @@ def test_target_model_parses_minimal_payload() -> None:
     )
 
     assert target_model.model.name == "SEAD Clearinghouse"
+    assert target_model.model.format_version == "1"
     assert target_model.entities == {}
     assert target_model.constraints == []
 
@@ -23,6 +28,7 @@ def test_target_model_parses_richer_entity_payload() -> None:
         {
             "model": {
                 "name": "SEAD Clearinghouse",
+                "format_version": "1",
                 "version": "2.0.0",
             },
             "entities": {
@@ -56,3 +62,39 @@ def test_target_model_parses_richer_entity_payload() -> None:
     assert list(location.columns) == ["location_name", "location_type_id"]
     assert location.columns["location_name"].required is True
     assert location.unique_sets == [["location_type_id", "location_name"]]
+
+
+def test_target_model_rejects_unknown_model_fields() -> None:
+    with pytest.raises(ValidationError):
+        TargetModel.model_validate(
+            {
+                "model": {
+                    "name": "SEAD Clearinghouse",
+                    "version": "2.0.0",
+                    "unknown_field": "nope",
+                },
+                "entities": {},
+            }
+        )
+
+
+def test_target_model_round_trip_preserves_format_version() -> None:
+    target_model = TargetModel.model_validate(
+        {
+            "model": {
+                "name": "SEAD Clearinghouse",
+                "format_version": "1",
+                "version": "2.0.0",
+            },
+            "entities": {
+                "location_type": {
+                    "role": "classifier",
+                    "columns": {"location_type": {"required": True}},
+                }
+            },
+        }
+    )
+
+    round_tripped = TargetModel.model_validate(target_model.model_dump(mode="json"))
+
+    assert round_tripped == target_model

--- a/tests/target_model/test_spec_files.py
+++ b/tests/target_model/test_spec_files.py
@@ -71,6 +71,8 @@ def test_sead_superset_spec_loads_and_validates() -> None:
     ecocode_definition = target_model.entities["ecocode_definition"]
     ecocode_group = target_model.entities["ecocode_group"]
     ecocode_system = target_model.entities["ecocode_system"]
+    taxonomic_order = target_model.entities["taxonomic_order"]
+    taxonomic_order_system = target_model.entities["taxonomic_order_system"]
     project = target_model.entities["project"]
     project_type = target_model.entities["project_type"]
     project_stage = target_model.entities["project_stage"]
@@ -85,7 +87,8 @@ def test_sead_superset_spec_loads_and_validates() -> None:
     sample_horizon = target_model.entities["sample_horizon"]
 
     assert target_model.model.name == "SEAD Clearinghouse Extended"
-    assert len(target_model.entities) == 96
+    assert target_model.model.format_version == "1"
+    assert len(target_model.entities) == 98
     assert {
         "analysis_value",
         "analysis_boolean_value",
@@ -124,6 +127,8 @@ def test_sead_superset_spec_loads_and_validates() -> None:
         "ecocode_group",
         "ecocode_definition",
         "ecocode",
+        "taxonomic_order_system",
+        "taxonomic_order",
         "rdb_system",
         "rdb_code",
         "rdb",
@@ -201,6 +206,11 @@ def test_sead_superset_spec_loads_and_validates() -> None:
     assert ecocode.aggregate_parent == "taxa_tree_master"
     assert any(foreign_key.entity == "ecocode_definition" for foreign_key in ecocode.foreign_keys)
     assert any(foreign_key.entity == "taxa_tree_master" for foreign_key in ecocode.foreign_keys)
+    assert taxonomic_order_system.target_table == "tbl_taxonomic_order_systems"
+    assert taxonomic_order.target_table == "tbl_taxonomic_order"
+    assert taxonomic_order.aggregate_parent == "taxa_tree_master"
+    assert any(foreign_key.entity == "taxa_tree_master" for foreign_key in taxonomic_order.foreign_keys)
+    assert any(foreign_key.entity == "taxonomic_order_system" for foreign_key in taxonomic_order.foreign_keys)
     assert rdb_system.target_table == "tbl_rdb_systems"
     assert any(foreign_key.entity == "location" for foreign_key in rdb_system.foreign_keys)
     assert any(foreign_key.entity == "citation" for foreign_key in rdb_system.foreign_keys)

--- a/tests/target_model/test_spec_validator.py
+++ b/tests/target_model/test_spec_validator.py
@@ -242,3 +242,30 @@ def test_validator_reports_invalid_identity_reconciliation_combinations() -> Non
         ("INVALID_IDENTITY_RECONCILIATION_COMBINATION", "derived_entity"),
         ("INVALID_IDENTITY_RECONCILIATION_COMBINATION", "ambiguous_lookup"),
     ]
+
+
+def test_validator_reports_invalid_allowed_values_usage() -> None:
+    target_model = TargetModel.model_validate(
+        {
+            "model": {
+                "name": "SEAD Clearinghouse",
+                "version": "2.0.0",
+            },
+            "entities": {
+                "sample": {
+                    "public_id": "sample_id",
+                    "columns": {
+                        "sample_kind": {"type": "string", "allowed_values": ["core", "control"]},
+                        "sample_status": {"type": "enum"},
+                    },
+                }
+            },
+        }
+    )
+
+    issues = TargetModelSpecValidator().validate(target_model)
+
+    assert [(issue.code, issue.field) for issue in issues] == [
+        ("ALLOWED_VALUES_REQUIRE_ENUM_TYPE", "sample_kind"),
+        ("ENUM_MISSING_ALLOWED_VALUES", "sample_status"),
+    ]

--- a/tests/validators/test_target_model_data_validators.py
+++ b/tests/validators/test_target_model_data_validators.py
@@ -3,6 +3,7 @@
 import pandas as pd
 
 from src.target_model.data_validators import (
+    AllowedValuesConformanceValidator,
     FKReferentialIntegrityConformanceValidator,
     NullabilityConformanceValidator,
     TypeCompatibilityConformanceValidator,
@@ -145,6 +146,43 @@ class TestTypeCompatibilityConformanceValidator:
         spec = make_entity_spec(columns={"created": ColumnSpec(type="date")})
         df = pd.DataFrame({"created": pd.to_datetime(["2024-01-01", "2024-06-15"])})
         assert not TypeCompatibilityConformanceValidator.validate(df, spec, "entity")
+
+
+# ---------------------------------------------------------------------------
+# AllowedValuesConformanceValidator
+# ---------------------------------------------------------------------------
+
+
+class TestAllowedValuesConformanceValidator:
+    def test_passes_when_values_are_within_allowed_set(self):
+        spec = make_entity_spec(columns={"status": ColumnSpec(type="enum", allowed_values=["open", "closed"])})
+        df = pd.DataFrame({"status": ["open", "closed", None]})
+
+        assert not AllowedValuesConformanceValidator.validate(df, spec, "entity")
+
+    def test_reports_values_outside_allowed_set(self):
+        spec = make_entity_spec(columns={"status": ColumnSpec(type="enum", allowed_values=["open", "closed"])})
+        df = pd.DataFrame({"status": ["open", "pending"]})
+
+        issues = AllowedValuesConformanceValidator.validate(df, spec, "entity")
+
+        assert len(issues) == 1
+        assert issues[0].code == "VALUE_NOT_IN_ALLOWED_SET"
+        assert issues[0].severity == "error"
+        assert issues[0].field == "status"
+        assert "pending" in (issues[0].suggestion or "")
+
+    def test_skips_columns_without_allowed_values(self):
+        spec = make_entity_spec(columns={"status": ColumnSpec(type="string")})
+        df = pd.DataFrame({"status": ["open", "pending"]})
+
+        assert not AllowedValuesConformanceValidator.validate(df, spec, "entity")
+
+    def test_skips_column_absent_from_dataframe(self):
+        spec = make_entity_spec(columns={"status": ColumnSpec(type="enum", allowed_values=["open", "closed"])})
+        df = pd.DataFrame({"other": [1]})
+
+        assert not AllowedValuesConformanceValidator.validate(df, spec, "entity")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- finish the remaining target-model conformance backlog slices on one clean branch
- add rule disabling, transitive FK support, orphan-fact checks, schema-aware append checks, generated-column metadata, enum/allowed-values support, severity controls, and the global conformance validator base
- close `TARGET_MODEL_CONFORMANCE_ENHANCEMENTS` as an active proposal, move ecosystem-dependent follow-up into future proposals, and track the remaining non-ecosystem follow-up in #457

## Testing
- `uv run pytest tests/target_model/test_schema_reference.py tests/target_model/test_models.py tests/model/test_target_model_conformance.py backend/tests/validators/test_target_model_validator.py backend/tests/services/test_validation_service.py -q`
- `python scripts/generate_schemas.py --check`
- `python scripts/generate_target_model_schema_reference.py --check`

## Notes
- PR branch: `target-model-conformance-closeout`
- follow-up issue remains open by design: #457