### PR TITLE
feat: Add semantic validation rules and loader options schema for Shape Shifter

### DIFF
--- a/.github/instructions/semantic-rules.instructions.md
+++ b/.github/instructions/semantic-rules.instructions.md
@@ -1,0 +1,39 @@
+---
+description: "Create and maintain semantic validation rules for Shape Shifter project YAML files."
+applyTo: "docs/rules/**/*.yml, docs/rules/**/*.md, backend/app/**/rules/**/*.yml, backend/app/**/validation/**/*.py"
+---
+
+# Shape Shifter semantic rules
+
+When asked to create, initialize, review, or maintain Shape Shifter semantic validation rules, follow the task-specific instruction file:
+
+```text
+docs/ai/semantic-rules-agent.md
+```
+
+Use generated JSON Schema for editor autocomplete and basic structural validation only. Do not duplicate the full schema as semantic rules.
+
+Semantic rules should capture contextual and cross-model constraints that JSON Schema cannot express well, such as:
+
+- source files that must exist
+- Excel sheets that must exist in a workbook
+- source tables or columns that must exist
+- target tables or columns that must exist
+- references between entities, mappings, lookups, and expressions
+- business rules implemented in the core layer
+- assumptions made by API-to-core mapping code
+
+Prefer implemented behavior over documentation. Use real project YAML examples, JSON Schema, Pydantic API models, API-to-core mapping, core business logic, and graphify when available.
+
+When creating initial conditional rules for entity types, the entity type contract table in `shapeshifter-configuration.instructions.md` provides a verified, high-confidence starting point. It lists required and optional fields per entity type and loader.
+
+Use stable rule IDs such as:
+
+```text
+entity.excel.sheetname_must_exist
+mapping.target_column_must_exist
+reference.entity_must_exist
+expression.references_must_resolve
+```
+
+Each rule should be actionable, include a severity, point to the relevant YAML path, explain the problem, and suggest a safe repair.

--- a/.github/instructions/shapeshifter-configuration.instructions.md
+++ b/.github/instructions/shapeshifter-configuration.instructions.md
@@ -1,120 +1,239 @@
 ---
-description: "Use when validating or editing shapeshifter.yml project files. Covers required structure, entity types, identity system, foreign keys, extra columns, dependency rules, data sources, common errors, and valid patterns."
+description: "Compact rules for validating or editing Shape Shifter project YAML. Covers high-risk structure, entity, identity, FK, dependency, append, directive, and false-positive checks."
 applyTo: "**/shapeshifter.yml,data/projects/**/*.yml,data/projects/**/*.yaml"
 ---
+
 # Shape Shifter YAML Validation Rules
 
-## Required Top-Level Structure
+Use this as the always-loaded compact rule source. Consult the full configuration guide only for detailed field semantics, examples, or project-version-specific behavior.
+
+## Project Shape
 
 ```yaml
 metadata:
-  name: string                    # REQUIRED
-  type: shapeshifter-project      # REQUIRED - exact string
-entities:                         # REQUIRED - at least 1 entity
-  <name>: { ... }
-options:                          # OPTIONAL
+  type: shapeshifter-project      # required, exact string
+  name: string                    # required
+entities:                         # required mapping
+  entity_name: { ... }
+options:                          # optional
   data_sources: {}
+  translations: {}
+  fixed_entity_types: {}
 ```
 
----
+- `metadata.type` is required and must be `shapeshifter-project`.
+- `metadata.name` is required.
+- `entities` must exist and should be non-empty for normal execution.
+- `options` is optional unless referenced.
 
-## Entity Types and Required Fields
+## Entity Types
 
-| Type | Required | Notes |
-|------|----------|-------|
-| `fixed` | `columns`, `values`, `public_id` | Values row width must equal columns length |
-| `sql` | `data_source`, `query` OR `table` | Not both; data_source must exist in `options.data_sources` |
-| `csv` | `filename` (or `options.filename`) | |
-| `xlsx` / `openpyxl` | `filename`, `sheet_name` (or in `options`) | |
-| `entity` | `source` | Source entity must exist |
-| `merged` | `items` list of sub-entity configs | Each branch gets a discriminator column |
+- `entity`: default when `type` is omitted; uses root/default source or another entity.
+- `fixed`: inline `values`; requires `columns`, `values`, and usually `public_id`.
+- `sql`: requires `data_source` and non-empty `query`.
+- `duckdb`: requires `query` and explicit `depends_on`; no `data_source`.
+- `merged`: requires `branches` and `public_id`; do not use obsolete `items`.
+- `csv`, `xlsx`, `openpyxl`: file loaders; commonly used in append/source contexts.
 
----
+Do not flag omitted `type` as an error if default `entity` semantics are valid.
 
-## Three-Tier Identity System
+## Entity Type Contracts
 
-| Tier | Field | Rule |
-|------|-------|------|
-| 1 | `system_id` | Auto-generated. All FK values are `system_id`. Never declare manually except in `fixed` entities. |
-| 2 | `keys` | Business keys for deduplication and FK matching. Optional. |
-| 3 | `public_id` | Target schema column name. Must end with `_id`. Required for fixed entities and FK parents. |
+Required and optional fields per entity type. For machine-readable rules, see `docs/rules/semantic_rules.yml`.
 
-**Fixed entity `columns` list must include `system_id` and `public_id`.**  
-**All other entity types: do not put `system_id` or `public_id` in `columns`.**
+| Type | Required fields | Required options | Optional fields | Notes |
+|---|---|---|---|---|
+| `entity` | none | none | `source`, `columns`, `foreign_keys`, `depends_on` | `source` names a parent entity; omit to use the project default data source |
+| `sql` | `data_source`, `query` | none | `columns`, `keys`, `public_id`, `depends_on` | `data_source` must match an `options.data_sources` entry; `"@internal"` is exempt |
+| `fixed` | `columns`, `values` | none | `public_id`, `keys`, `column_types`, `extra_columns` | Row width must match `columns` length |
+| `csv`, `tsv` | — | `options.filename` | `options.delimiter`, `options.encoding` | `csv` and `tsv` use the same loader class |
+| `xlsx` | — | `options.filename` | `options.sheet_name`, `options.sanitize_header` | File loader, pandas engine |
+| `openpyxl` | — | `options.filename` | `options.sheet_name`, `options.range`, `options.sanitize_header` | File loader, openpyxl engine; supports cell range |
+| `merged` | `branches`, `public_id` | none | `keys`, `foreign_keys` | Each branch requires `name` + `source` |
+| `duckdb` | `query`, `depends_on` | none | `columns`, `keys`, `public_id` | No `data_source` |
 
----
+## Identity
 
-## Foreign Key Rules
+- `system_id`: internal local ID. FK values always reference parent `system_id`.
+- `keys`: business keys for matching/deduplication. Should be `list[string]`; `[]` is valid.
+- `public_id`: target/export ID and FK column name. Must end with `_id`.
 
-- `entity` must reference an existing entity.
-- `local_keys` must exist in: `columns`, source entity columns, or `extra_columns`.
+Rules:
+
+- FK values are local parent `system_id` values, not external target IDs.
+- FK column names are derived from the parent `public_id`.
+- `public_id` is required for fixed, merged, and FK parent entities.
+- Non-fixed entities should not declare/import `system_id` in `columns`.
+- Fixed entities may intentionally preserve explicit `system_id`.
+- Fixed `system_id` values must be positive integers, unique, and non-null.
+- `surrogate_id` is legacy; prefer `public_id` in new edits but do not reject legacy configs solely for it.
+
+## Fixed Entities
+
+- `columns` and `values` are required.
+- Every `values` row width must match `columns`.
+- Primitive single-column `values` require exactly one column.
+- Explicit-identity fixed entities include both `system_id` and `public_id` in `columns`.
+- `values: []` can be valid for fixed union/schema-parent entities with `append`.
+- `column_types` applies only to fixed entities.
+- `column_types` keys must exist in `columns`.
+- Allowed fixed types: `int`, `string`, `float`, `bool`, `date`; use `int`, not `integer`.
+- Fixed type precedence: `column_types`, then `options.fixed_entity_types.conventions`, then `_id -> int`, then no inferred type.
+- Invalid non-empty `_id` values such as `"53.0"`, `"abc"`, or booleans are validation problems.
+
+## SQL, Internal SQL, and DuckDB
+
+- External `type: sql` requires `data_source`, `query`, and a matching `options.data_sources` entry.
+- `data_source: "@internal"` is an exception: no `options.data_sources` entry is required.
+- Internal SQL should list referenced processed entities in `depends_on`.
+- `type: duckdb` requires `query` and `depends_on`, and does not require `data_source`.
+- Queried FK values in internal SQL/DuckDB are local `system_id` values.
+
+## Merged Entities
+
+- `branches` is required and must be non-empty.
+- Each branch requires `name` and `source`.
+- Branch names must be unique.
+- Branch `source` must reference an existing entity.
+- Branch source entities should define `public_id`.
+- A config with `branches` should have `type: merged`.
+
+## Foreign Keys
+
+- Non-cross FKs require `entity`, `local_keys`, and `remote_keys`.
+- FK `entity` must exist and must not be self-referential.
+- `local_keys` and `remote_keys` must have equal length.
+- `local_keys` must exist in the child entity at the relevant stage.
 - `remote_keys` must exist in the target entity.
-- No self-references.
-- `extra_columns` + FK using that column is **valid** — not an error.
-- Use `defer_dependency: true` on a FK config to break circular dependency chains.
+- `extra_columns` values used in FK joins are valid.
+- `how: cross` should not have `local_keys` or `remote_keys`.
+- `defer_dependency: true` is valid only as an explicit advanced cycle-breaking FK setting.
 
----
+External-ID pattern:
+
+- If a child already contains external parent IDs, keep them in a distinct business-key column, for example `sead_method_group_id`.
+- Join that column to the parent business key.
+- Let FK linking add the local FK column named from parent `public_id`.
+
+## FK Constraints
+
+Supported keys: `cardinality`, `allow_unmatched_left`, `allow_unmatched_right`, `require_unique_left`, `require_unique_right`, `allow_null_keys`, `allow_row_decrease`.
+
+- `cardinality` must be `one_to_one`, `many_to_one`, `one_to_many`, or `many_to_many`.
+- `many_to_one` is the common lookup/reference pattern.
+- `require_unique_right: true` is common for lookup/reference entities.
+- `allow_unmatched_left: false` enforces required matches.
+- `allow_row_decrease: false` catches accidental filtering.
+- If `allow_null_keys` is omitted for lookup-style `left` joins, missing local key parts may remain unresolved rather than hard-erroring.
+- Do not tighten constraints unless relationship intent is clear.
+
+## Dependencies
+
+Dependency sources:
+
+- `depends_on`
+- `source`
+- `foreign_keys[].entity`, unless deferred
+- `append[].source`
+- `merged.branches[].source`
+- filters such as `exists_in.other_entity`
+- visible internal SQL/DuckDB references
+
+Rules:
+
+- `depends_on` should be `list[string]`; `[]` is valid.
+- All dependency references must point to existing entities.
+- Dependency graph must be acyclic unless a specific FK uses `defer_dependency: true`.
+- Add only minimal dependencies needed to satisfy actual references.
 
 ## Extra Columns
 
-```yaml
-extra_columns:
-  col_name: 42               # constant integer/string
-  col_name: other_col        # copies an existing column
-  col_name: "{a} {b}"        # interpolated string
-  col_name: "=concat(a, b)"  # DSL formula (concat/upper/lower/trim/substr/coalesce)
-```
+Valid forms: copy, constant, interpolation, DSL formula, and escaped literal `==value`.
 
-Evaluated before unnest. Deferred automatically if a referenced column is not yet available.
+- `extra_columns` must be a mapping.
+- Formula DSL functions include at least `concat`, `upper`, `lower`, `trim`, `substr`, `coalesce`, `replace`, `regex_extract`, `to_decimal`, `to_int`, `to_float`, `to_str`, and `to_date`.
+- Formula expressions are not arbitrary code.
+- Interpolation is null-safe.
+- Some `extra_columns` may be deferred until referenced columns appear later; avoid premature missing-column findings.
 
----
+## Append
 
-## Dependency Rules
+- `append` concatenates sources before FK linking and unnesting.
+- Append sources may be fixed, SQL, source/entity-based, or project-version-dependent file loaders.
+- Fixed append requires `values`; SQL append requires `data_source` and `query`.
+- Source-based append can omit `type`; `source` implies entity/source append.
+- Append `source` must reference an existing entity and should be represented in `depends_on`.
+- Append schemas must align with parent columns.
 
-- Topological sort: dependencies must exist and be acyclic.
-- Dependency sources: `source:`, `foreign_keys[].entity`, `depends_on: []`.
-- Circular deps → add `defer_dependency: true` on the FK that creates the cycle.
+Inherited by append sources unless overridden: `columns`, `drop_duplicates`, `drop_empty_rows`, `replacements`, `filters`, `check_column_names`.
 
----
+Not inherited: `public_id`/`surrogate_id`, `keys`, `foreign_keys`, `unnest`, `depends_on`, `source`, `type`.
+
+If append item has `source`, do not inherit loader-driving fields: `type`, `values`, `query`, `data_source`, or `sql`.
+
+## Unnest
+
+- `var_name` and `value_name` are required when `unnest` is configured.
+- `value_vars` should be present and non-empty.
+- `id_vars` is optional; empty `id_vars` may deserve a warning.
+- `id_vars` and `value_vars` may use `@value:`.
+- `var_name` and `value_name` must differ and should not conflict with existing columns.
+- `value_vars` should not overlap with `id_vars`.
+
+## Data Quality and Replacements
+
+- `drop_duplicates`: valid as bool, `list[string]`, `@value:` string, or mapping with `columns`.
+- `drop_empty_rows`: valid as bool, `list[string]`, or `dict[string, list[any]]`.
+- `filters` must be a list of mappings; `exists_in` requires `column`, `other_entity`, and optional `other_column`.
+- `replacements` must be a mapping by column and may use mappings, legacy blank-out/fill forms, or ordered rule lists.
+- Do not simplify advanced replacement rules unless behavior is equivalent.
 
 ## Directives
 
-```yaml
-field: "@include: ${DIR}/file.yml"   # inline YAML inclusion with recursive resolution of directives and references
-field: "@load: ${DIR}/file.yml"      # load YAML file
-field: "@value: path.to.key"         # value lookup
-field: "${ENV_VAR}"                  # environment variable substitution
-```
+Preserve during review/editing:
 
-- Preserve directives in YAML and API layer; never resolve them in services.
-- Resolve only at the API → Core boundary (`ProjectMapper.to_core()`).
-- Core always receives resolved values — never raw directives.
+- `@include: path/to/file.yml`
+- `@load: path.or.external.spec`
+- `@value: entities.entity.property`
+- `${ENV_VAR}`
 
----
+Rules:
 
-## Common Errors
-
-| Error | Cause |
-|-------|-------|
-| Column width mismatch | Fixed entity: `columns` length ≠ row width in `values` |
-| Missing `public_id` | Fixed entity, or entity that is a FK parent |
-| Missing `data_source` | `type: sql` entity |
-| Missing `sheet_name` | `type: xlsx` or `openpyxl` entity |
-| Missing `source` | `type: entity` derived entity |
-| Non-existent FK target | `foreign_keys[].entity` not in entities |
-| `system_id` in `columns` | Non-fixed entity declaring `system_id` manually |
-| Circular dependency | No `defer_dependency: true` on the FK that breaks the cycle |
-
----
+- Do not inline or pre-resolve directives unless explicitly asked.
+- `@include:` loads YAML and recursively resolves directives/references in included data.
+- `@load:` loads external/raw data without resolving directives introduced later.
+- `@value:` references another config value by path.
+- Treat unresolved directives as residual risk, not automatic errors, unless visibly invalid.
 
 ## Materialized Entities
 
-```yaml
-materialized:
-  enabled: true
-  timestamp: "2024-01-15T10:30:00Z"
-  source_hash: "abc123"
-```
+If `materialized` is supported by the active project version:
 
-- Treat as frozen snapshot; do not re-validate data.
-- FK references reflect dependencies at time of materialization.
+- Treat it as a frozen snapshot.
+- Do not re-validate snapshot data as raw extraction input.
+- Validate surrounding entity config and references.
+- If support is unclear, state the assumption instead of declaring the field valid or invalid.
+
+## High-Risk False Positives
+
+Do not auto-flag these as errors:
+
+- `type` omitted when default `entity` semantics are valid.
+- `keys: []` or `depends_on: []`.
+- `source: null` or omitted source for root/default source.
+- `values: []` on fixed union/schema-parent entities with append.
+- `data_source: "@internal"` without `options.data_sources`.
+- `type: duckdb` without `data_source`.
+- `extra_columns` used as FK join keys.
+- Source-based append without `type`.
+- Legacy `surrogate_id`.
+- Left joins with permissive constraints for sparse or optional relationships.
+- Lookup-style `left` joins with omitted `allow_null_keys`.
+
+## Review Practice
+
+- Separate definite errors from warnings, assumptions, and project-version-dependent checks.
+- Report entity path, violated rule, impact, and smallest safe fix.
+- Preserve comments, ordering, directives, and local style.
+- Never invent data-source names, table names, sheet names, source columns, or target columns.
+- Only claim validation passed if it actually ran successfully.

--- a/.github/skills/shapeshifter-configuration/SKILL.md
+++ b/.github/skills/shapeshifter-configuration/SKILL.md
@@ -1,47 +1,149 @@
 ---
 name: shapeshifter-configuration
-description: 'Validate, review, repair, or author Shape Shifter project YAML such as shapeshifter.yml and data/projects/*.yml. Use for entity configuration, fixed/sql/csv/xlsx/entity/merged entities, identity rules, foreign keys, extra_columns, dependency cycles, directives, materialized entities, and project validation troubleshooting.'
+description: 'Validate, review, repair, or author Shape Shifter project YAML such as shapeshifter.yml and data/projects/*.yml. Use for entity configuration, fixed/sql/csv/xlsx/entity/merged entities, identity rules, foreign keys, extra_columns, dependency cycles, directives, materialized entities, and project validation errors.'
 argument-hint: 'Path to shapeshifter.yml or describe the configuration problem'
----
+-------------------------------------------------------------------------------
 
 # Shape Shifter Configuration
 
-Use this skill for focused work on Shape Shifter project YAML files. The rule source is [`shapeshifter-configuration.instructions.md`](../../instructions/shapeshifter-configuration.instructions.md); load it before validating, reviewing, or editing project YAML.
+Use this skill for deep analysis, repair, and authoring of Shape Shifter project YAML files.
 
-## When To Use
+Before making validation decisions, load [`references/shapeshifter-configuration.instructions.md`](references/shapeshifter-configuration.instructions.md). Treat that file as authoritative. Use project docs only to clarify local intent, naming patterns, and workflow-specific conventions.
 
-Use this skill when the user asks to:
+Expected input: a path to `shapeshifter.yml`, a `data/projects/*.yml` or `data/projects/*.yaml` file, or a description of a configuration problem.
 
-- validate, review, create, or repair `shapeshifter.yml` or `data/projects/*.yml`
-- troubleshoot entity dependencies, foreign keys, identity fields, loaders, data sources, directives, or materialized entities
-- explain project validation errors or turn a rough entity description into valid config
+## Scope
+
+Use this skill after it has been selected to:
+
+* validate, review, create, or repair Shape Shifter project YAML
+* troubleshoot entity dependencies, foreign keys, identity fields, loaders, data sources, directives, or materialized entities
+* explain project validation errors
+* turn a rough entity description into valid configuration
+* review an existing project for correctness, maintainability, and migration risk before running imports
+* diagnose pipeline failures caused by config shape, linkage, dependency, or identity assumptions
 
 Do not use it for Python validator implementation, backend API changes, frontend YAML editor work, or BugsCEP reconciliation-policy YAML unless the task also edits a Shape Shifter project config.
+
+## Expert Mindset
+
+Analyze configuration in this order:
+
+1. Structural validity: top-level shape, required fields, and YAML parseability.
+2. Entity semantics: each entity type satisfies its required contract.
+3. Identity integrity: `system_id`, `keys`, and `public_id` follow the three-tier identity model.
+4. Relationship correctness: FK joins, key columns, and dependency order align.
+5. Runtime behavior risk: transforms, duplicate handling, directives, and materialized state behave as intended.
+
+Prefer deterministic, minimal fixes. Avoid broad rewrites when a local change solves the issue.
 
 ## Workflow
 
 1. Identify the config file and intended workflow.
-2. Load the rule source and any nearby project docs the user points to.
-3. Parse YAML structurally before reasoning about business intent.
-4. Check required top-level fields, entity type rules, identity fields, foreign keys, dependencies, loader options, `extra_columns`, directives, and materialization rules.
-5. Edit only when the user asked for changes; keep the smallest fix that preserves ordering, comments, and style.
-6. Do not invent unknown data-source names, table names, sheet names, or target columns.
-7. For circular dependencies, prefer `defer_dependency: true` on the FK that breaks the cycle.
-8. For FK columns produced by `extra_columns`, keep the produced value and the FK together.
+2. Load `references/shapeshifter-configuration.instructions.md`. If `docs/rules/semantic_rules.yml` exists in the repository, also load it for machine-readable conditional rules.
+3. Load nearby project docs only when they clarify local intent or patterns.
+4. Parse YAML structurally before reasoning about business intent.
+5. Validate top-level requirements: `metadata.name`, `metadata.type: shapeshifter-project`, and `entities`.
+6. Validate each entity against type-specific rules from the reference file.
+7. Validate the identity model:
 
-Preserve directives such as `@include:`, `@load:`,  `@value:`, and `${ENV_VAR}` in YAML. Resolution belongs at the API-to-core mapper boundary.
+   * `system_id` is internal and auto-managed except explicit fixed-entity cases
+   * `keys` are business keys for matching and deduplication
+   * `public_id` names exported identity and FK target columns and must end with `_id`
+8. Validate foreign keys and dependencies:
+
+   * referenced entity exists
+   * `local_keys` and `remote_keys` exist at the correct stage
+   * no self-reference
+   * dependency graph is acyclic unless the specific cycle edge uses `defer_dependency: true`
+9. Validate transforms and shaping behavior:
+
+   * `extra_columns` constants, copies, interpolation, and formulas are coherent
+   * columns used by FKs may be produced by `extra_columns`
+   * `unnest`, `append`, and duplicate/drop rules are intentional and key-safe
+10. Preserve directives such as `@include:`, `@load:`, `@value:`, and `${ENV_VAR}`. Do not inline or pre-resolve them during config review or editing.
+11. Treat materialized entities as frozen snapshots. Do not re-validate snapshot data as if it were raw source extraction.
+12. Edit only when asked. Preserve ordering, comments, and local style where practical.
+13. Never invent unknown data-source names, table names, sheet names, source columns, or target columns.
+14. Run project validation after changes when the repository and validation command are available.
+
+## High-Value Checks
+
+Prioritize checks that catch common project failures:
+
+* Fixed entity `columns` width must match every row in `values`.
+* Explicit-identity fixed entities include both `system_id` and `public_id` in `columns`.
+* Fixed entities without `system_id` in `columns` are valid; it will be auto-generated.
+* Non-fixed entities must not manually declare `system_id` in `columns`.
+* SQL entities must have `data_source` and `query`.
+* SQL `data_source` must exist in `options.data_sources`.
+* `xlsx` and `openpyxl` entities must define `filename` and `sheet_name`, directly or through `options`.
+* `entity` entities must reference an existing `source`.
+* FK target entities must exist.
+* FK `local_keys` must exist in the child entity at the correct stage.
+* FK `remote_keys` must exist in the target entity.
+* Child FK values are local parent `system_id` values, not external business IDs.
+* `surrogate_id` is legacy — prefer `public_id` in new edits, but do not reject legacy configs solely for using `surrogate_id`.
+* When a child already has external parent IDs, keep those as business-key columns and let FK linking add the local-ID FK column separately.
+* If an FK depends on an `extra_columns` value, keep the produced column and FK config consistent in the same entity.
+* For dependency cycles, prefer `defer_dependency: true` on the specific FK edge that creates the cycle.
+
+## Valid Advanced Patterns
+
+Do not auto-flag these as errors:
+
+* `extra_columns` values used in FK joins.
+* Empty `keys: []` when intentional for lookup, bridge, or workflow-specific entities.
+* `source:` set to null or empty when valid for the entity type and workflow.
+* Materialized fixed entities with historical shape that differs from non-materialized authoring style.
+* Left joins or permissive constraints used for sparse or optional relationships.
+* Deferred `extra_columns` when referenced columns are not available until a later stage.
+
+If uncertain, state the assumption and ask one focused question instead of proposing speculative edits.
+
+## Review Output Contract
+
+For reviews, always return:
+
+1. Findings ordered by severity: `Critical`, `High`, `Medium`, `Low`.
+2. For each finding:
+
+   * entity path
+   * exact rule violated
+   * impact
+   * smallest safe fix
+3. Validation status and command evidence.
+4. Remaining risks, assumptions, or open questions.
+
+When no issues are found, explicitly say so and still call out residual risk areas such as runtime SQL shape drift, unresolved environment variables, source-file drift, or project-specific assumptions not visible in YAML.
+
+## Edit Output Contract
+
+For edits, return:
+
+1. Edited path.
+2. Short change summary.
+3. Validation performed.
+4. Remaining risks or decisions.
+
+Keep fixes minimal. Preserve comments, ordering, and local formatting where practical.
 
 ## Validation Commands
 
-Use repository commands only when validation is requested or after making config changes:
+Use repository commands only when validation is requested or after making config changes.
+
+Prefer `rtk` when available:
 
 ```bash
-rtk make test-validate
 rtk uv run python scripts/validate_project.py <path-to-shapeshifter.yml> --workflow all --log-level ERROR
 ```
 
-If `rtk` fails, retry without it. Do not claim validation passed unless the command completed successfully or VS Code diagnostics report no errors for the edited file.
+If `rtk` is unavailable or fails for wrapper-related reasons, retry without it:
 
-## Output Format
+```bash
+uv run python scripts/validate_project.py <path-to-shapeshifter.yml> --workflow all --log-level ERROR
+```
 
-For reviews, lead with findings ordered by severity, then concrete fixes, validation, and open questions. For edits, include the edited path, short change summary, validation performed, and remaining risks or decisions.
+Do not claim validation passed unless the command completed successfully or VS Code diagnostics report no errors for the edited file.
+
+Optionally run targeted workflow slices if available in the repository, but report exactly what was and was not run.

--- a/.github/skills/shapeshifter-configuration/references/shapeshifter-configuration.instructions.md
+++ b/.github/skills/shapeshifter-configuration/references/shapeshifter-configuration.instructions.md
@@ -1,0 +1,1 @@
+../../../instructions/shapeshifter-configuration.instructions.md

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,18 +34,34 @@
     "editor.minimap.enabled": false,
     "files.autoSave": "afterDelay",
     "files.watcherExclude": {
-        "**/tmp/**": true,
-        "**/test_data/**": true,
+        "**/.git/**": true,
         "**/.venv/**": true,
         "**/venv/**": true,
-        "**/.git/**": true,
         "**/node_modules/**": true,
+        "**/frontend/node_modules/**": true,
+        "**/frontend/dist/**": true,
+        "**/frontend/coverage/**": true,
+        "**/frontend/.vite/**": true,
+        "**/frontend/.nuxt/**": true,
+        "**/frontend/.output/**": true,
+        "**/frontend/playwright-report/**": true,
+        "**/frontend/test-results/**": true,
+
+        "**/tmp/**": true,
         "**/data/**": true,
         "**/graphify-out/**": true,
-        "**/docs/**": true,
+        "**/output/**": true,
+        "**/logs/**": true,
+
         "**/__pycache__/**": true,
         "**/.pytest_cache/**": true,
         "**/.ruff_cache/**": true,
+        "**/.mypy_cache/**": true,
+        "**/.tox/**": true,
+        "**/.nox/**": true,
+        "**/htmlcov/**": true,
+
+        "**/sead-tools/**": true
     },
     "git.confirmSync": false,
     "gitlens.rebaseEditor.ordering": "asc",
@@ -70,7 +86,6 @@
         }
     },
     "peacock.remoteColor": "#336c73",
-    // "python.analysis.logLevel": "Trace",
     "python.analysis.aiHoverSummaries": false,
     "python.analysis.autoFormatStrings": true,
     "python.analysis.autoImportCompletions": true,
@@ -183,5 +198,7 @@
         "/home/roger/source/sead_shape_shifter/frontend/src/schemas/projectSchema.json": [
             "**/shapeshifter.yml"
         ]
-    }
+    },
+    "vitest.filesWatcherInclude": "frontend/src/**/*",
+    "vitest.watchOnStartup": false
 }

--- a/backend/app/models/entity.py
+++ b/backend/app/models/entity.py
@@ -1,5 +1,7 @@
 """Pydantic models for an entity."""
 
+from __future__ import annotations
+
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator
@@ -58,6 +60,10 @@ class ForeignKeyConfig(BaseModel):
     )
     drop_remote_id: bool = Field(default=False, description="Drop remote surrogate ID after merge")
     constraints: ForeignKeyConstraints | None = Field(default=None, description="Foreign key constraints")
+    defer_dependency: bool = Field(
+        default=False,
+        description="Break a dependency cycle by deferring the FK link to a final pass. Use only when circular references are unavoidable.",
+    )
 
     @field_validator("local_keys", "remote_keys", mode="before")
     @classmethod
@@ -173,6 +179,26 @@ class Entity(BaseModel):
     drop_empty_rows: bool | list[str] = Field(default=False, description="Drop empty rows")
     check_column_names: bool = Field(default=True, description="Validate column names")
     values: list[list[Any]] | None = Field(default=None, description="Fixed values for 'fixed' type entities")
+    options: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Loader-specific options (filename, sheet_name, range, etc.). Required keys depend on entity type.",
+    )
+    check_functional_dependency: bool = Field(
+        default=True,
+        description="Whether to check functional dependency when dropping duplicates. Default True.",
+    )
+    surrogate_name: str | None = Field(
+        default=None,
+        description="Fixed entity type name used when the entity represents a controlled vocabulary type.",
+    )
+    type_names: list[str] = Field(
+        default_factory=list,
+        description="Column name list for unnest type columns, referenced by @value: in other entities.",
+    )
+    replacements: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Value replacement rules applied during data extraction.",
+    )
 
     @field_validator("name")
     @classmethod

--- a/docs/ai/semantic-rules-agent.md
+++ b/docs/ai/semantic-rules-agent.md
@@ -1,0 +1,354 @@
+---
+description: "Create and maintain semantic validation rules for Shape Shifter project YAML files."
+applyTo: "docs/rules/**/*.yml, docs/rules/**/*.md, backend/app/**/rules/**/*.yml, backend/app/**/validation/**/*.py"
+---
+
+# Semantic Rules Agent Instructions
+
+Shape Shifter uses YAML project files to describe transformations between source relational models and target relational models. The generated JSON Schema supports editor autocomplete and basic structural validation, but many important rules are semantic, contextual, or cross-model and cannot be fully expressed in JSON Schema.
+
+Create and maintain semantic rule files that describe those rules in a stable, AI-readable format.
+
+## Source priority
+
+Inspect any available sources in this priority order:
+
+1. Existing Shape Shifter project YAML files, especially large real examples with many entities.
+2. The entity type contract table in `shapeshifter-configuration.instructions.md` — a verified, high-confidence summary of required and optional fields per entity type.
+3. Generated JSON Schema.
+4. Pydantic API models.
+5. API-to-core mapping layer.
+6. Core/domain layer with business rules.
+7. Graphify knowledge graph, if available.
+
+Prefer implemented behavior over documentation when they disagree.
+
+## Goal
+
+Extract rules that help validate, explain, debug, and improve Shape Shifter project YAML files.
+
+Focus on rules that:
+
+- depend on discriminator fields such as `type`, `kind`, `source`, or `target`
+- require fields only in specific contexts
+- refer to existing files, sheets, tables, columns, entities, mappings, joins, lookups, or expressions
+- express business rules not captured by JSON Schema
+- prevent common user mistakes
+- can produce actionable diagnostics and repair suggestions
+
+Do not duplicate trivial JSON Schema rules unless they are useful for explanation or repair.
+
+## Recommended files
+
+For the first version, prefer:
+
+```text
+docs/rules/semantic_rules.yml
+docs/rules/README.md
+```
+
+If the catalog grows, split by area:
+
+```text
+docs/rules/entities.yml
+docs/rules/sources.yml
+docs/rules/mappings.yml
+docs/rules/targets.yml
+docs/rules/expressions.yml
+```
+
+## Rule format
+
+Use this YAML structure:
+
+```yaml
+version: 1
+
+rules:
+  - id: entity.xlsx.requires_filename
+    title: xlsx entities require options.filename
+    severity: error
+    category: conditional
+    applies_to: entities.*
+    when:
+      type: xlsx
+    require:
+      - options.filename
+    message: xlsx entities must define options.filename.
+    fix: Add options.filename pointing to the .xlsx or .xls file.
+```
+
+Use stable rule IDs:
+
+```text
+<area>.<context>.<rule_name>
+```
+
+Examples:
+
+```text
+entity.xlsx.requires_filename
+entity.xlsx.sheet_name_must_exist
+entity.openpyxl.requires_filename
+entity.openpyxl.sheet_name_must_exist
+mapping.target_column_must_exist
+reference.entity_must_exist
+expression.value_reference_must_resolve
+```
+
+## Rule fields
+
+Use these fields where applicable:
+
+```yaml
+id: stable.machine_readable.id
+title: Short human-readable title
+severity: error | warning | info
+category: structural | conditional | project_resource | source_model | target_model | transformation | consistency
+applies_to: YAML path pattern
+when: condition for the rule
+require: list of required fields
+check: semantic check descriptor
+message: diagnostic message
+fix: suggested repair
+confidence: high | medium | low
+agent_guidance: optional deeper guidance for AI repair
+examples: optional valid/invalid examples
+source: optional code/model/schema references used to infer the rule
+```
+
+## Categories
+
+Use one or more of these categories:
+
+```yaml
+structural: Basic shape rules that are important for explanation.
+conditional: Rules depending on discriminator values such as type: excel.
+project_resource: Files, paths, Excel sheets, CSV headers, encodings, delimiters, or external resources.
+source_model: Source tables, source columns, source datatypes, joins, and lookup sources.
+target_model: Target tables, target columns, constraints, keys, and relationships.
+transformation: Expressions, mappings, constants, references, lookups, casts, and value transformations.
+consistency: Rules involving several parts of the same project file.
+```
+
+## Check kinds
+
+Reuse these check kinds before inventing new ones:
+
+```yaml
+exists
+not_empty
+one_of
+matches_regex
+unique_within_scope
+reference_resolves
+project_file_exists
+project_file_has_extension
+excel_sheet_exists
+csv_column_exists
+source_table_exists
+source_column_exists
+target_table_exists
+target_column_exists
+expression_parses
+expression_reference_resolves
+type_compatible
+join_key_exists
+lookup_key_exists
+```
+
+Example:
+
+```yaml
+- id: entity.xlsx.sheet_name_must_exist
+  title: Sheet must exist in workbook
+  severity: error
+  category: project_resource
+  applies_to: entities.*
+  when:
+    type: xlsx
+  check:
+    kind: excel_sheet_exists
+    file: options.filename
+    sheet: options.sheet_name
+  message: Sheet '{{ options.sheet_name }}' does not exist in '{{ options.filename }}'.
+  fix: Choose one of the sheets available in the referenced workbook.
+```
+
+## Deriving rules
+
+### From project YAML files
+
+Look for repeated patterns across real entities. Compare entities with the same `type` and identify required options, optional options, naming conventions, references, source fields, target fields, and common transformation structures.
+
+If a rule is inferred only from repeated examples, add `confidence: medium`. Do not create hard `error` rules from weak conventions.
+
+### From JSON Schema
+
+Use the schema to identify allowed values, object structure, required fields, discriminated unions, descriptions, aliases, defaults, and examples.
+
+Do not copy the whole schema into semantic rules. Extract only rules that help diagnostics, explanation, repair, or contextual validation.
+
+### From Pydantic API models
+
+Inspect model fields, validators, discriminators, default values, descriptions, aliases, and enums.
+
+Rules inferred from validators are usually high confidence. When a field is optional in the API model but required later by core logic in a specific context, create a semantic rule.
+
+### From API-to-core mapping
+
+Look for fields that are transformed, renamed, normalized, defaulted, expanded, or dropped.
+
+Create rules when the mapping layer assumes that a field exists, a string matches a known name, a reference resolves, or a source field maps to a target field.
+
+### From core/business logic
+
+Prioritize core-layer checks, exceptions, guard clauses, validation functions, and runtime assumptions.
+
+Good signals include:
+
+```text
+raise ValueError(...)
+raise ValidationError(...)
+assert ...
+if missing:
+if not found:
+if type == ...
+if source.kind == ...
+```
+
+Create rules for conditions that would otherwise fail at runtime.
+
+### From graphify
+
+Use graphify to find related symbols and code paths. Useful searches include:
+
+```text
+entity model
+excel source
+sheetname
+filename
+validator
+mapping
+target column
+source column
+reference
+transformation expression
+```
+
+Follow edges from API models to mappers, validators, services, and core transformation logic. Prefer rules confirmed by multiple connected sources.
+
+## Confidence
+
+Add `confidence` when a rule is inferred rather than explicit.
+
+Use:
+
+```yaml
+confidence: high
+```
+
+when confirmed by code, schema, or explicit validation.
+
+Use:
+
+```yaml
+confidence: medium
+```
+
+when inferred from repeated project examples and consistent naming.
+
+Use:
+
+```yaml
+confidence: low
+```
+
+only for candidate rules that need human review.
+
+Do not create hard `error` rules from low-confidence inference.
+
+## Source references
+
+Include source references where useful:
+
+```yaml
+source:
+  - kind: pydantic_model
+    path: backend/app/api/models/project.py
+    symbol: ExcelEntityOptions
+  - kind: core_validator
+    path: backend/app/core/project/validation.py
+    symbol: validate_excel_entity
+  - kind: example_project
+    path: examples/large_project.yml
+    note: All Excel entities define options.filename and options.sheetname.
+```
+
+Source references help maintainers and AI agents. They do not need to be perfect, but they should be useful.
+
+## Agent guidance
+
+Add `agent_guidance` when repair requires reasoning:
+
+```yaml
+agent_guidance:
+  explanation: >
+    Excel-backed entities must refer to an existing workbook and sheet. JSON Schema
+    can require the fields, but it cannot know which files or sheets exist in the
+    project workspace.
+  repair_strategy:
+    - Inspect options.filename.
+    - Check whether the file exists relative to the project file.
+    - If the workbook exists, list available sheet names.
+    - Suggest the closest matching sheet name when there is an obvious typo.
+    - Do not change the sheet name automatically unless the match is unambiguous.
+  safe_autofix: false
+```
+
+## Good first rule families
+
+Start with a small high-confidence catalog. Prefer 10-30 useful rules over a large noisy file.
+
+Good first families:
+
+```text
+entity.<type>.requires_options
+entity.<type>.required_option_fields
+entity.<type>.resource_must_exist
+entity.<type>.source_columns_must_exist
+mapping.target_table_must_exist
+mapping.target_column_must_exist
+mapping.source_column_must_exist
+reference.entity_must_exist
+expression.references_must_resolve
+lookup.keys_must_exist
+target.required_fields_must_be_mapped
+```
+
+## Diagnostic quality
+
+Every rule should help produce diagnostics like:
+
+```text
+Error entity.excel.sheetname_must_exist at entities.abc.options.sheetname:
+Sheet 'Sheet1' does not exist in 'somefile.xlsx'.
+
+Suggested fix:
+Choose one of the sheets available in the referenced workbook.
+```
+
+Prefer diagnostics that identify the exact YAML location, failed rule ID, invalid value, expected value or available alternatives, and safe repair suggestion.
+
+## Avoid
+
+Do not:
+
+- replace the generated JSON Schema
+- duplicate every schema property as a semantic rule
+- invent rules not supported by examples, schema, models, mapping code, core code, or graphify
+- make low-confidence inferred conventions into hard errors
+- create a complex expression language unless existing fields are insufficient
+- hide uncertainty
+- write vague messages such as "invalid configuration"
+- propose unsafe autofixes for ambiguous source or target mappings

--- a/docs/proposals/YAML_SCHEMA_AUTHORITATIVE_REFERENCE.md
+++ b/docs/proposals/YAML_SCHEMA_AUTHORITATIVE_REFERENCE.md
@@ -1,0 +1,387 @@
+# Proposal: Authoritative YAML Schema Reference
+
+**Status:** Draft
+**Scope:** Schema generation, Entity Pydantic model, configuration instructions
+**Goal:** Provide AI coding agents and tooling with a complete, structured reference for Shape Shifter YAML structure.
+
+---
+
+## Summary
+
+The JSON schemas used by the Monaco editor (`entitySchema.json`, `projectSchema.json`) are generated from Pydantic API models and omit six user-authored YAML fields, the `defer_dependency` FK option, loader-specific options, and directives. This gap is not a problem for human editors but prevents AI coding agents from reliably validating or authoring Shape Shifter YAML. The fix has three parts: add the missing fields to the `Entity` and `ForeignKeyConfig` Pydantic models, generate loader option sub-schemas from `DriverSchema`, and add an entity type contract table to the configuration instructions.
+
+## Problem
+
+`entitySchema.json` is generated from the `Entity` Pydantic model via `model_json_schema()`. The `Entity` model only declares structurally significant fields (identity, FK, columns, filters). Fields that exist in valid project YAML but are not on the model never appear in the schema.
+
+The following fields are missing from the generated schema:
+
+| Missing field                                 | Defined on                                           | Example usage                                   | Gap                                                                                          |
+|-----------------------------------------------|------------------------------------------------------|-------------------------------------------------|----------------------------------------------------------------------------------------------|
+| `options`                                     | `TableConfig` (raw dict)                             | `openpyxl`, `xlsx`, `csv` entities              | Loader options like `filename`, `sheet_name`, `range` are invisible                          |
+| `check_functional_dependency`                 | `TableConfig.check_functional_dependency`            | `sample`, `site`, `site_location`               | Common validation toggle absent                                                              |
+| `surrogate_name`                              | `TableConfig.surrogate_name`                         | `sample_description_type`, `site_property_type` | Fixed entity type naming absent                                                              |
+| `type_names`                                  | YAML sidecar (raw dict)                              | `sample_description_type`                       | Column list referenced by `@value:` in other entities; absent from schema                    |
+| `replacements`                                | `TableConfig.replacements`                           | Data quality transforms                         | Value replacement dict absent from schema                                                    |
+| `defer_dependency`                            | `ForeignKeyConfig.defer_dependency`                  | FK cycle-breaking                               | Advanced FK setting absent from `ForeignKeyConfig` API model                                 |
+| `materialized`                                | `TableConfig.materialized` / `MaterializationConfig` | `site_type`, `site_type_group`                  | Written by the materialization service, not human authors; schema exposure is lower priority |
+| Directives (`@include:`, `@value:`, `@load:`) | `src/configuration/resolve.py`                       | Throughout YAML                                 | Resolved before models see the data; cannot be represented as JSON Schema properties         |
+
+Not all gaps have the same fix. The table below categorizes them:
+
+| Category                            | Fields                                                                                   | Approach                                                                                                                              |
+|-------------------------------------|------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------|
+| **Add to `Entity` model**           | `options`, `check_functional_dependency`, `surrogate_name`, `type_names`, `replacements` | Add Pydantic fields; re-run schema generation                                                                                         |
+| **Add to `ForeignKeyConfig` model** | `defer_dependency`                                                                       | Add Pydantic field; re-run schema generation                                                                                          |
+| **Deferred — system-managed**       | `materialized`                                                                           | Written by the materialization service after processing; not a user-authored field. Expose in a follow-up if schema consumers need it |
+| **Deferred — not representable**    | Directives (`@include:`, `@value:`, `@load:`)                                            | These are string patterns resolved at config load time. JSON Schema cannot validate or document their syntax                          |
+
+Additionally, the schema cannot express conditional requirements such as "if `type` is `openpyxl`, then `options.filename` is required." JSON Schema Draft 7 (the current target) does not support `if/then/else`. This gap requires the entity type contract table in the configuration instructions.
+
+AI coding agents use the JSON schema as a primary reference when analyzing or editing Shape Shifter YAML. Without these fields, an agent cannot know that an `openpyxl` entity requires `options.filename`, that `replacements` is a valid key, or that `defer_dependency` can be set on a foreign key. The SKILL.md skill loads `shapeshifter-configuration.instructions.md`, which contains prose rules for some of these, but prose is not machine-readable and does not cover all cases. The semantic rules instructions in `docs/ai/semantic-rules-agent.md` define a machine-readable YAML rule catalog format that can express these conditional requirements, but no catalog exists yet.
+
+## Scope
+
+This proposal covers:
+
+- Adding the six missing fields to the `Entity` and `ForeignKeyConfig` Pydantic models.
+- Extending `generate_schemas.py` to generate loader option sub-schemas from `DriverSchema`.
+- Adding an entity type contract table to `shapeshifter-configuration.instructions.md`.
+- Creating an initial semantic rules catalog in `docs/rules/semantic_rules.yml` that encodes the entity type contracts as machine-readable conditional rules.
+
+It does not cover the `materialized` field, directives, Monaco editor UX, Pydantic validation of `options` contents, or replacing the existing schema generation pipeline.
+
+## Non-Goals
+
+- This proposal does not replace the Pydantic `Entity` model with a complete YAML schema.
+- This proposal does not upgrade to JSON Schema Draft 9+ for conditional logic.
+- This proposal does not create a separate YAML schema file.
+- This proposal does not address Monaco editor validation — the schemas remain autocomplete-only.
+- This proposal does not add the `materialized` field (system-managed, not user-authored).
+- This proposal does not represent directives (`@include:`, `@value:`, `@load:`) in JSON Schema (not representable).
+
+## Current Behavior
+
+### Schema generation
+
+`scripts/generate_schemas.py` calls `Entity.model_json_schema()` and writes the result to `frontend/src/schemas/entitySchema.json`. The `Entity` model in `backend/app/models/entity.py` has no `options` field.
+
+### Project model
+
+`Project.entities` is typed as `dict[str, dict[str, Any]]` — raw dicts. The `Project` model does not validate entity contents against the `Entity` Pydantic model. Entities flow through as raw YAML, and the `ProjectMapper` bridges API and Core layers.
+
+### Core model
+
+`TableConfig` in `src/model.py` reads `options` directly from the underlying YAML dict via a property. The core model is a thin wrapper, not a schema.
+
+### Loader schemas
+
+Each loader declares its accepted options as a `DriverSchema` class variable on the loader class. `DriverSchemaRegistry` (in `src/loaders/driver_metadata.py`) collects these from all registered loader classes and exposes them via `DriverSchemaRegistry.all()`. These schemas are used by the frontend for data source configuration but are not connected to entity schema generation.
+
+## Proposed Design
+
+### 1. Add missing fields to the `Entity` and `ForeignKeyConfig` Pydantic models
+
+Add the following fields to `backend/app/models/entity.py`:
+
+```python
+options: dict[str, Any] = Field(
+    default_factory=dict,
+    description="Loader-specific options (filename, sheet_name, range, etc.). Required keys depend on entity type."
+)
+check_functional_dependency: bool = Field(
+    default=True,
+    description="Whether to check functional dependency when dropping duplicates. Default True."
+)
+surrogate_name: str | None = Field(
+    default=None,
+    description="Fixed entity type name used when the entity represents a controlled vocabulary type."
+)
+type_names: list[str] = Field(
+    default_factory=list,
+    description="Column name list for unnest type columns, referenced by @value: in other entities."
+)
+replacements: dict[str, Any] = Field(
+    default_factory=dict,
+    description="Value replacement rules applied during data extraction."
+)
+```
+
+Add `defer_dependency` to `ForeignKeyConfig` in the same file:
+
+```python
+defer_dependency: bool = Field(
+    default=False,
+    description="Break a dependency cycle by deferring the FK link to a final pass. Use only when circular references are unavoidable."
+)
+```
+
+These additions surface all user-authored YAML fields in the generated schema. None of them change validation behaviour — they widen what the schema describes, not what the backend accepts.
+
+### 2. Generate loader option sub-schemas from `DriverSchema`
+
+Extend `scripts/generate_schemas.py` to call `DriverSchemaRegistry.all()` (imported from `src.loaders.driver_metadata`) and convert each loader's `DriverSchema` into a JSON Schema fragment. For each loader, `FieldMetadata` entries map to JSON Schema properties: `name` → property key, `type` → JSON Schema type (`file_path` → `string`), `required` fields go into the `required` array, and `description` and `default` pass through directly. The resulting fragments are added to the `options` property in `entitySchema.json` as a `oneOf` array.
+
+The generated structure would be:
+
+```json
+"options": {
+  "type": "object",
+  "description": "Loader-specific options. Required keys depend on entity type.",
+  "oneOf": [
+    {
+      "description": "Options for type: openpyxl",
+      "properties": {
+        "filename": { "type": "string", "description": "Path to .xlsx file" },
+        "sheet_name": { "type": "string", "description": "Sheet name to load" },
+        "range": { "type": "string", "description": "Cell range to load (e.g., A1:D10)" },
+        "sanitize_header": { "type": "boolean", "description": "Whether to sanitize column headers", "default": true }
+      },
+      "required": ["filename"]
+    },
+    {
+      "description": "Options for type: xlsx",
+      "properties": {
+        "filename": { "type": "string", "description": "Path to .xlsx or .xls file" },
+        "sheet_name": { "type": "string", "description": "Sheet name to load" },
+        "sanitize_header": { "type": "boolean", "description": "Whether to sanitize column headers", "default": true }
+      },
+      "required": ["filename"]
+    }
+  ]
+}
+```
+
+This gives AI agents structured, loader-specific option information. The `oneOf` is a hint, not a conditional constraint — Monaco autocomplete may not use it perfectly, but it provides the information.
+
+### 3. Add entity type contract table to configuration instructions
+
+Add a structured table to `.github/instructions/shapeshifter-configuration.instructions.md` that explicitly lists required and optional fields per entity type. This is the authoritative reference for AI agents loading the SKILL.md skill:
+
+```markdown
+## Entity Type Contracts
+
+Required and optional fields per entity type. `options.*` fields are loader-specific; see loader schemas for detail.
+
+| Type         | Required fields                       | Required options   | Optional fields                                                  | Notes                                                                                                                                  |
+|--------------|---------------------------------------|--------------------|------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| `entity`     | none (default when `type` is omitted) | none               | `source`, `columns`, `foreign_keys`, `depends_on`                | `source` names a parent entity to derive from; omit `source` to load from the project default data source                              |
+| `sql`        | `data_source`, `query`                | none               | `columns`, `keys`, `public_id`, `depends_on`                     | `data_source` must match an entry in `options.data_sources`; `data_source: "@internal"` is exempt and requires no `data_sources` entry |
+| `fixed`      | `columns`, `values`                   | none               | `public_id`, `keys`, `column_types`, `extra_columns`             | Row width must match `columns` length                                                                                                  |
+| `csv`, `tsv` | —                                     | `options.filename` | `options.delimiter`, `options.encoding`                          | File loader; `csv` and `tsv` use the same loader class                                                                                 |
+| `xlsx`       | —                                     | `options.filename` | `options.sheet_name`, `options.sanitize_header`                  | File loader, pandas engine                                                                                                             |
+| `openpyxl`   | —                                     | `options.filename` | `options.sheet_name`, `options.range`, `options.sanitize_header` | File loader, openpyxl engine with range support                                                                                        |
+| `merged`     | `branches`, `public_id`               | none               | `keys`, `foreign_keys`                                           | Each branch needs `name` + `source`                                                                                                    |
+| `duckdb`     | `query`, `depends_on`                 | none               | `columns`, `keys`, `public_id`                                   | No `data_source`                                                                                                                       |
+```
+
+This table is parseable by AI agents and provides the conditional logic that JSON Schema cannot express.
+
+### 4. Create initial semantic rules catalog
+
+Create `docs/rules/semantic_rules.yml` following `docs/ai/semantic-rules-agent.md`. The entity type contract table in step 3 provides the verified source for the initial rule set. Each row maps to one or more rules:
+
+- A `conditional` rule for required `options` fields per file-loader type (e.g., `xlsx` and `openpyxl` require `options.filename`).
+- A `structural` rule for required top-level fields per type (e.g., `sql` requires `data_source` and `query`).
+- A `project_resource` rule where the resource can be verified at runtime (e.g., `options.filename` must point to an existing file).
+
+This gives AI agents a machine-readable rule catalog that complements the prose instructions in `shapeshifter-configuration.instructions.md` and the `SKILL.md` skill. The `SKILL.md` workflow loads this file when present, making it the primary reference for programmatic and AI-assisted semantic validation.
+
+## Alternatives Considered
+
+### Add all missing fields to `Entity` as hand-curated Pydantic fields
+
+Add every YAML field, including `materialized`, `type_names`, `replacements`, and similar fields, by hand to `Entity`. This proposal already adds the six straightforward fields. The distinction here is "hand-curate all fields including ambiguous ones" — the risk is that fields like `materialized` (system-managed) or arbitrary sidecar fields (e.g., project-specific cross-reference keys) would appear as first-class model fields without clear semantics. The proposal draws the line at fields that have a defined role and are user-authored.
+
+### Upgrade to JSON Schema Draft 9+ with `if/then/else`
+
+This would allow conditional constraints like "if `type` is `openpyxl`, then `options.filename` is required." The Monaco YAML language server supports Draft 2020-12, but the conditional logic would still need a source of truth for what each type requires. This is a surface improvement on top of the structural gap.
+
+### Create a separate YAML schema file
+
+A dedicated schema file, not derived from Pydantic, could be the authoritative YAML reference. This is the most complete approach. The maintenance burden is prohibitive: a hand-curated schema would diverge from the Pydantic models over time, and the Pydantic-derived schema would still be required for Monaco. Any new entity field or loader option would need two updates.
+
+## Risks And Tradeoffs
+
+- **`oneOf` in Monaco autocomplete:** Monaco's YAML language server may not use `oneOf` for autocomplete effectively. The loader option sub-schemas are primarily for AI agent consumption, not editor UX.
+- **Schema drift:** If a loader adds or removes `FieldMetadata`, the generated schema will change on next run. This is acceptable — the schema should track the loaders.
+- **`options` as `dict[str, Any]`:** Adding this to `Entity` means the Pydantic model no longer validates `options` contents. This is consistent with current behavior — `options` validation happens at the loader boundary.
+- **Instruction table maintenance:** The type contract table needs updates when new entity types or required fields are added. This is a documentation maintenance cost, but it is the same cost as updating the prose rules.
+
+## Testing And Validation
+
+- Run `python scripts/generate_schemas.py` and verify `entitySchema.json` now includes `options` with loader sub-schemas.
+- Verify `make lint` passes (Black + isort).
+- Verify existing tests pass (`make test`).
+- Manually verify Monaco editor loads the updated schema without errors in the frontend.
+- Verify the SKILL.md skill loads the updated instructions file successfully.
+
+## Acceptance Criteria
+
+- `entitySchema.json` includes `options`, `check_functional_dependency`, `surrogate_name`, `type_names`, and `replacements` as properties on entity definitions.
+- `entitySchema.json` includes `defer_dependency` as a property on foreign key definitions.
+- `entitySchema.json` includes loader-specific option sub-schemas for `openpyxl`, `xlsx`, and `csv` loaders.
+- `shapeshifter-configuration.instructions.md` includes an entity type contract table.
+- Schema generation is driven by `DriverSchema` from the loader registry, not hardcoded.
+- Existing tests pass.
+- Monaco editor loads the updated schema without errors.
+- `docs/rules/semantic_rules.yml` exists with conditional rules covering required and optional `options` fields for each entity type, following the format in `docs/ai/semantic-rules-agent.md`.
+
+## Recommended Delivery Order
+
+1. Add `options`, `check_functional_dependency`, `surrogate_name`, `type_names`, `replacements` to `Entity` in `backend/app/models/entity.py`.
+2. Add `defer_dependency` to `ForeignKeyConfig` in the same file.
+3. Extend `generate_schemas.py` to generate loader option sub-schemas from `DriverSchema`.
+4. Add entity type contract table to `shapeshifter-configuration.instructions.md`.
+5. Create `docs/rules/semantic_rules.yml` from the entity type contracts using `docs/ai/semantic-rules-agent.md`.
+6. Run schema generation and validate output.
+7. Run full test suite.
+
+## Final Recommendation
+
+Implement the three-part fix. The changes are small and self-contained; the maintenance cost is bounded by the loader registry and the instruction table.
+
+---
+
+## Task Plan
+
+### Work Breakdown
+
+#### Area 1 — Pydantic model fields
+
+Objective: surface all user-authored YAML fields in the generated schema by adding them to the API models.
+
+- [x] Open `backend/app/models/entity.py` and locate the `Entity` model.
+- [x] Add `options: dict[str, Any]` field with description.
+- [x] Add `check_functional_dependency: bool` field with `default=True` and description.
+- [x] Add `surrogate_name: str | None` field with `default=None` and description.
+- [x] Add `type_names: list[str]` field with `default_factory=list` and description.
+- [x] Add `replacements: dict[str, Any]` field with `default_factory=dict` and description.
+- [x] Locate `ForeignKeyConfig` in the same file and add `defer_dependency: bool` with `default=False` and description.
+- [x] Verify `from __future__ import annotations` and `Any` import are present.
+- [x] Run `make lint` and confirm no type errors on the model file.
+
+Completion condition: all six fields appear in the model; `make lint` passes; no existing tests break.
+
+#### Area 2 — Loader option sub-schemas
+
+Objective: make `entitySchema.json` include structured, loader-specific option schemas derived from the loader registry.
+
+- [x] Open `scripts/generate_schemas.py` and review the current schema generation logic.
+- [x] Import `DriverSchemaRegistry` from `src.loaders.driver_metadata`.
+- [x] Call `DriverSchemaRegistry.all()` to retrieve all registered loader schemas.
+- [x] Write a conversion function that maps each `DriverSchema` → JSON Schema fragment:
+  - `FieldMetadata.name` → property key
+  - `FieldMetadata.type` → JSON Schema type (`file_path` → `string`)
+  - `FieldMetadata.required` → `required` array entry
+  - `FieldMetadata.description` and `FieldMetadata.default` → pass through
+- [x] Build a `oneOf` array from all loader fragments and assign it to the `options` property in the generated schema.
+- [x] Run `python scripts/generate_schemas.py` and inspect `frontend/src/schemas/entitySchema.json`.
+- [x] Confirm `options.oneOf` contains entries for `openpyxl`, `xlsx`, and `csv` loaders.
+- [x] Confirm `filename` appears in `required` for file-loader entries.
+
+Completion condition: `entitySchema.json` contains `options` with a populated `oneOf`; generation is driven by the registry, not hardcoded values.
+
+#### Area 3 — Configuration instructions
+
+Objective: add a machine-parseable entity type contract table to `shapeshifter-configuration.instructions.md` so AI agents loading the SKILL.md skill have complete per-type field requirements.
+
+- [x] Confirm the entity type contract table has been added to `.github/instructions/shapeshifter-configuration.instructions.md` (done as part of proposal alignment — verify it is present and accurate).
+- [x] Cross-check each table row against the current loader and mapper behavior:
+  - [x] `entity`: no required options; `source` optional.
+  - [x] `sql`: `data_source` and `query` required; `"@internal"` exemption documented.
+  - [x] `fixed`: `columns` and `values` required; row width rule present.
+  - [x] `csv`/`tsv`: `options.filename` required; same loader class noted.
+  - [x] `xlsx`: `options.filename` required; `options.sheet_name` optional.
+  - [x] `openpyxl`: `options.filename` required; `options.sheet_name` and `options.range` optional.
+  - [x] `merged`: `branches` and `public_id` required.
+  - [x] `duckdb`: `query` and `depends_on` required; no `data_source`.
+- [x] Verify the symlink at `.github/skills/shapeshifter-configuration/references/shapeshifter-configuration.instructions.md` reflects the updated file.
+
+Completion condition: entity type contract table is present, all rows are accurate, and the SKILL.md symlink resolves correctly.
+
+#### Area 4 — Semantic rules catalog
+
+Objective: create `docs/rules/semantic_rules.yml` as a machine-readable rule catalog covering entity type contracts and common error patterns using `docs/ai/semantic-rules-agent.md`.
+
+- [x] Create `docs/rules/semantic_rules.yml` with `version: 1` header.
+- [x] Add `conditional` rules for required options per file-loader type:
+  - [x] `entity.xlsx.requires_filename` — `options.filename` required when `type: xlsx`.
+  - [x] `entity.openpyxl.requires_filename` — `options.filename` required when `type: openpyxl`.
+  - [x] `entity.csv.requires_filename` — `options.filename` required when `type: csv`.
+  - [x] `entity.tsv.requires_filename` — `options.filename` required when `type: tsv`.
+- [x] Add `structural` rules for required top-level fields:
+  - [x] `entity.sql.requires_data_source` — `data_source` required when `type: sql` (exempt: `"@internal"`).
+  - [x] `entity.sql.requires_query` — `query` required when `type: sql`.
+  - [x] `entity.fixed.requires_columns` — `columns` required when `type: fixed`.
+  - [x] `entity.fixed.requires_values` — `values` required when `type: fixed`.
+  - [x] `entity.merged.requires_branches` — `branches` required when `type: merged`.
+  - [x] `entity.merged.requires_public_id` — `public_id` required when `type: merged`.
+  - [x] `entity.duckdb.requires_query` — `query` required when `type: duckdb`.
+  - [x] `entity.duckdb.requires_depends_on` — `depends_on` required when `type: duckdb`.
+- [x] Add `project_resource` rules for file existence:
+  - [x] `entity.xlsx.filename_must_exist` — `options.filename` must point to an existing file.
+  - [x] `entity.openpyxl.filename_must_exist` — `options.filename` must point to an existing file.
+  - [x] `entity.csv.filename_must_exist` — `options.filename` must point to an existing file.
+- [x] Add `consistency` rules for cross-entity references:
+  - [x] `reference.entity_must_exist` — every entity referenced in `source`, `foreign_keys[].entity`, `append[].source`, or `merged.branches[].source` must exist in `entities`.
+- [x] Add `source` references for each rule pointing to the relevant Pydantic model, loader, or instruction file.
+- [x] Create `docs/rules/README.md` with a short description of the catalog and its intended use.
+- [x] Verify YAML parses cleanly (`python -c "import yaml; yaml.safe_load(open('docs/rules/semantic_rules.yml'))"`).
+
+Completion condition: `docs/rules/semantic_rules.yml` parses cleanly; all entity types from the contract table are covered; `docs/rules/README.md` exists.
+
+#### Area 5 — Validation and testing
+
+Objective: confirm the full change set passes all existing checks and produces the expected outputs.
+
+- [x] Run `python scripts/generate_schemas.py` and verify no errors.
+- [x] Inspect `frontend/src/schemas/entitySchema.json`:
+  - [x] `options` property is present with `oneOf`.
+  - [x] `check_functional_dependency`, `surrogate_name`, `type_names`, `replacements` are present as entity properties.
+  - [x] `defer_dependency` is present as a foreign key property.
+- [x] Run `make lint` (Black + isort) and confirm it passes.
+- [x] Run `make test` and confirm all tests pass.
+- [x] Load the updated schema in the frontend Monaco editor and verify no console errors.
+- [x] Run `uv run python scripts/validate_project.py <path-to-shapeshifter.yml> --workflow all --log-level ERROR` on at least one real project file and confirm validation behavior is unchanged.
+
+Completion condition: all checks pass; schema output matches acceptance criteria; project validation behavior is unchanged.
+
+---
+
+### Progress Tracker
+
+| Area                           | Status      | Notes                                                   |
+|--------------------------------|-------------|---------------------------------------------------------|
+| 1 — Pydantic model fields      | Complete    | `backend/app/models/entity.py`                          |
+| 2 — Loader option sub-schemas  | Complete    | `scripts/generate_schemas.py`                           |
+| 3 — Configuration instructions | Complete    | Table verified accurate; symlink confirmed              |
+| 4 — Semantic rules catalog     | Complete    | `docs/rules/semantic_rules.yml`, `docs/rules/README.md` |
+| 5 — Validation and testing     | Not started | Depends on areas 1–4                                    |
+
+---
+
+### Definition Of Done
+
+- [x] `entitySchema.json` includes `options` (with `oneOf` loader sub-schemas), `check_functional_dependency`, `surrogate_name`, `type_names`, `replacements`, and `defer_dependency`.
+- [x] Schema generation reads from `DriverSchemaRegistry`; no loader option values are hardcoded in `generate_schemas.py`.
+- [x] Entity type contract table is present and accurate in `shapeshifter-configuration.instructions.md`.
+- [x] `docs/rules/semantic_rules.yml` exists, parses cleanly, and covers all entity types in the contract table.
+- [x] `docs/rules/README.md` exists with a brief description of the rule catalog.
+- [x] `make lint` passes.
+- [x] `make test` passes with no regressions.
+- [x] Monaco editor loads the updated schema without errors.
+- [x] At least one real project file validates without behavior change.
+
+---
+
+### Deliverables
+
+| Deliverable | Description | Status |
+|---|---|---|
+| `backend/app/models/entity.py` | Add five fields to `Entity`; add `defer_dependency` to `ForeignKeyConfig` | Done |
+| `scripts/generate_schemas.py` | Extend to generate loader option sub-schemas from `DriverSchemaRegistry` | Done |
+| `frontend/src/schemas/entitySchema.json` | Regenerated output with new fields and `options.oneOf` |Done |
+| `.github/instructions/shapeshifter-configuration.instructions.md` | Entity type contract table added | Done |
+| `docs/rules/semantic_rules.yml` | Initial semantic rules catalog | Done |
+| `docs/rules/README.md` | Brief description and usage guide for the rule catalog | Done |

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -1,0 +1,45 @@
+# Shape Shifter Semantic Rules
+
+This directory contains machine-readable semantic validation rules for Shape Shifter project YAML files.
+
+## Files
+
+| File                 | Description                                                                           |
+|----------------------|---------------------------------------------------------------------------------------|
+| `semantic_rules.yml` | Initial rule catalog covering entity type contracts and cross-entity reference checks |
+
+## Purpose
+
+The generated JSON Schema (`frontend/src/schemas/entitySchema.json`) supports editor autocomplete and basic structural validation. It cannot express conditional or contextual rules such as:
+
+- "an `xlsx` entity must define `options.filename`"
+- "a `duckdb` entity must define both `query` and `depends_on`"
+- "every entity referenced in `source` or `foreign_keys[].entity` must exist in `entities`"
+
+The rule files in this directory capture those constraints in a stable, AI-readable format. AI coding agents load these rules via the `shapeshifter-configuration` skill to validate, explain, and repair project YAML.
+
+## Rule format
+
+Rules follow the format defined in `docs/ai/semantic-rules-agent.md`. Each rule has:
+
+- `id` — stable identifier (`<area>.<context>.<rule_name>`)
+- `title` — short description
+- `severity` — `error`, `warning`, or `info`
+- `category` — `conditional`, `structural`, `project_resource`, or `consistency`
+- `applies_to` — YAML path pattern
+- `when` — condition (discriminator match)
+- `require` or `check` — what to validate
+- `message` — diagnostic message
+- `fix` — suggested repair
+- `source` — code or documentation references
+
+## Adding rules
+
+1. Follow the format in `docs/ai/semantic-rules-agent.md`.
+2. Use stable rule IDs. Do not reuse or rename existing IDs.
+3. Add `confidence: medium` for rules inferred from examples rather than explicit code or schema.
+4. Verify the file parses cleanly after editing:
+
+```bash
+python -c "import yaml; yaml.safe_load(open('docs/rules/semantic_rules.yml'))"
+```

--- a/docs/rules/semantic_rules.yml
+++ b/docs/rules/semantic_rules.yml
@@ -1,0 +1,367 @@
+version: 1
+
+# Semantic validation rules for Shape Shifter project YAML files.
+#
+# These rules capture contextual and conditional constraints that the generated
+# JSON Schema cannot express. Rules are grouped by category:
+#
+#   conditional      — rules depending on discriminator values such as type: xlsx
+#   structural       — basic required-field rules important for explanation and repair
+#   project_resource — file paths and external resources that must exist
+#   consistency      — cross-entity reference checks
+#
+# Rule IDs follow the pattern: <area>.<context>.<rule_name>
+# See docs/ai/semantic-rules-agent.md for format details.
+
+rules:
+
+  # ---------------------------------------------------------------------------
+  # conditional — required options per file-loader entity type
+  # ---------------------------------------------------------------------------
+
+  - id: entity.xlsx.requires_filename
+    title: xlsx entities require options.filename
+    severity: error
+    category: conditional
+    applies_to: entities.*
+    when:
+      type: xlsx
+    require:
+      - options.filename
+    message: "xlsx entities must define options.filename."
+    fix: "Add options.filename pointing to the .xlsx or .xls file."
+    confidence: high
+    source:
+      - kind: loader
+        path: src/loaders/excel_loaders.py
+        symbol: PandasLoader
+        note: "DriverSchema declares filename as required=True for the xlsx driver."
+      - kind: instructions
+        path: .github/instructions/shapeshifter-configuration.instructions.md
+        note: "Entity type contract table: xlsx requires options.filename."
+
+  - id: entity.openpyxl.requires_filename
+    title: openpyxl entities require options.filename
+    severity: error
+    category: conditional
+    applies_to: entities.*
+    when:
+      type: openpyxl
+    require:
+      - options.filename
+    message: "openpyxl entities must define options.filename."
+    fix: "Add options.filename pointing to the .xlsx file."
+    confidence: high
+    source:
+      - kind: loader
+        path: src/loaders/excel_loaders.py
+        symbol: OpenPyxlLoader
+        note: "DriverSchema declares filename as required=True for the openpyxl driver."
+      - kind: instructions
+        path: .github/instructions/shapeshifter-configuration.instructions.md
+        note: "Entity type contract table: openpyxl requires options.filename."
+
+  - id: entity.csv.requires_filename
+    title: csv entities require options.filename
+    severity: error
+    category: conditional
+    applies_to: entities.*
+    when:
+      type: csv
+    require:
+      - options.filename
+    message: "csv entities must define options.filename."
+    fix: "Add options.filename pointing to the .csv file."
+    confidence: high
+    source:
+      - kind: loader
+        path: src/loaders/file_loaders.py
+        symbol: CsvLoader
+        note: "DriverSchema declares filename as required=True for the csv driver."
+      - kind: instructions
+        path: .github/instructions/shapeshifter-configuration.instructions.md
+        note: "Entity type contract table: csv requires options.filename."
+
+  - id: entity.tsv.requires_filename
+    title: tsv entities require options.filename
+    severity: error
+    category: conditional
+    applies_to: entities.*
+    when:
+      type: tsv
+    require:
+      - options.filename
+    message: "tsv entities must define options.filename."
+    fix: "Add options.filename pointing to the .tsv file."
+    confidence: high
+    source:
+      - kind: loader
+        path: src/loaders/file_loaders.py
+        symbol: CsvLoader
+        note: "tsv is registered as an alias for the csv loader; the same DriverSchema applies with filename required=True."
+      - kind: instructions
+        path: .github/instructions/shapeshifter-configuration.instructions.md
+        note: "Entity type contract table: tsv uses the csv loader and requires options.filename."
+
+  # ---------------------------------------------------------------------------
+  # structural — required top-level fields per entity type
+  # ---------------------------------------------------------------------------
+
+  - id: entity.sql.requires_data_source
+    title: sql entities require data_source
+    severity: error
+    category: structural
+    applies_to: entities.*
+    when:
+      type: sql
+    require:
+      - data_source
+    message: "sql entities must define data_source."
+    fix: >-
+      Add data_source referencing a name in options.data_sources, or use
+      data_source: "@internal" for queries against already-processed entities.
+    confidence: high
+    agent_guidance:
+      explanation: >
+        External sql entities reference a named data source that must exist in options.data_sources.
+        The special value "@internal" is the only exception — it signals that the entity queries
+        already-processed entities within the same run and does not require a data_sources entry.
+      repair_strategy:
+        - Check options.data_sources for available data source names.
+        - 'If the query reads from other entities processed in the same run, use data_source: "@internal".'
+        - Do not remove data_source; add it if missing.
+      safe_autofix: false
+    source:
+      - kind: instructions
+        path: .github/instructions/shapeshifter-configuration.instructions.md
+        note: "Entity type contract table: sql requires data_source."
+      - kind: loader
+        path: src/loaders/sql_loaders.py
+        note: "SqlLoader validates that data_source is present at load time."
+
+  - id: entity.sql.requires_query
+    title: sql entities require query
+    severity: error
+    category: structural
+    applies_to: entities.*
+    when:
+      type: sql
+    require:
+      - query
+    message: "sql entities must define query."
+    fix: "Add query with the SQL statement to execute against the configured data source."
+    confidence: high
+    source:
+      - kind: instructions
+        path: .github/instructions/shapeshifter-configuration.instructions.md
+        note: "Entity type contract table: sql requires query."
+
+  - id: entity.fixed.requires_columns
+    title: fixed entities require columns
+    severity: error
+    category: structural
+    applies_to: entities.*
+    when:
+      type: fixed
+    require:
+      - columns
+    message: "fixed entities must define columns."
+    fix: "Add columns listing the column names that match each position in the values rows."
+    confidence: high
+    source:
+      - kind: loader
+        path: src/loaders/fixed_loader.py
+        symbol: FixedLoader
+        note: "FixedLoader requires columns to construct the DataFrame."
+      - kind: instructions
+        path: .github/instructions/shapeshifter-configuration.instructions.md
+        note: "Entity type contract table: fixed requires columns."
+
+  - id: entity.fixed.requires_values
+    title: fixed entities require values
+    severity: error
+    category: structural
+    applies_to: entities.*
+    when:
+      type: fixed
+    require:
+      - values
+    message: "fixed entities must define values."
+    fix: "Add values with a list of rows. Each row must have the same width as columns."
+    confidence: high
+    source:
+      - kind: loader
+        path: src/loaders/fixed_loader.py
+        symbol: FixedLoader
+        note: "FixedLoader requires values to construct the DataFrame."
+      - kind: instructions
+        path: .github/instructions/shapeshifter-configuration.instructions.md
+        note: "Entity type contract table: fixed requires values."
+
+  - id: entity.merged.requires_branches
+    title: merged entities require branches
+    severity: error
+    category: structural
+    applies_to: entities.*
+    when:
+      type: merged
+    require:
+      - branches
+    message: "merged entities must define branches."
+    fix: "Add branches listing the entities to merge. Each branch requires name and source."
+    confidence: high
+    source:
+      - kind: pydantic_model
+        path: backend/app/models/entity.py
+        symbol: Entity
+        note: "branches field is required for merged entities in the API model."
+      - kind: instructions
+        path: .github/instructions/shapeshifter-configuration.instructions.md
+        note: "Entity type contract table: merged requires branches."
+
+  - id: entity.merged.requires_public_id
+    title: merged entities require public_id
+    severity: error
+    category: structural
+    applies_to: entities.*
+    when:
+      type: merged
+    require:
+      - public_id
+    message: "merged entities must define public_id."
+    fix: "Add public_id with a column name ending in _id (for example, site_id) to identify the merged entity."
+    confidence: high
+    source:
+      - kind: instructions
+        path: .github/instructions/shapeshifter-configuration.instructions.md
+        note: "Entity type contract table: merged requires public_id."
+
+  - id: entity.duckdb.requires_query
+    title: duckdb entities require query
+    severity: error
+    category: structural
+    applies_to: entities.*
+    when:
+      type: duckdb
+    require:
+      - query
+    message: "duckdb entities must define query."
+    fix: "Add query with the DuckDB SQL statement. The query can reference other already-processed entities by name."
+    confidence: high
+    source:
+      - kind: loader
+        path: src/loaders/duckdb_loader/duckdb_loader.py
+        symbol: DuckDbLoader
+        note: "DuckDbLoader raises ValueError if sql_query is absent at load time."
+      - kind: instructions
+        path: .github/instructions/shapeshifter-configuration.instructions.md
+        note: "Entity type contract table: duckdb requires query."
+
+  - id: entity.duckdb.requires_depends_on
+    title: duckdb entities require depends_on
+    severity: error
+    category: structural
+    applies_to: entities.*
+    when:
+      type: duckdb
+    require:
+      - depends_on
+    message: "duckdb entities must define depends_on listing the entities they query."
+    fix: "Add depends_on listing every entity name referenced in the DuckDB query to ensure correct processing order."
+    confidence: high
+    source:
+      - kind: instructions
+        path: .github/instructions/shapeshifter-configuration.instructions.md
+        note: "Entity type contract table: duckdb requires depends_on."
+      - kind: core
+        path: src/workflow.py
+        note: "Workflow builds the dependency graph from depends_on; missing entries cause incorrect processing order."
+
+  # ---------------------------------------------------------------------------
+  # project_resource — options.filename must point to an existing file
+  # ---------------------------------------------------------------------------
+
+  - id: entity.xlsx.filename_must_exist
+    title: xlsx options.filename must point to an existing file
+    severity: error
+    category: project_resource
+    applies_to: entities.*
+    when:
+      type: xlsx
+    check:
+      kind: project_file_exists
+      file: options.filename
+    message: "options.filename '{{ options.filename }}' does not exist."
+    fix: "Check the path relative to the project file. Verify the file name and extension (.xlsx or .xls)."
+    confidence: high
+    source:
+      - kind: loader
+        path: src/loaders/excel_loaders.py
+        symbol: PandasLoader
+        note: "PandasLoader raises FileNotFoundError if the file does not exist."
+
+  - id: entity.openpyxl.filename_must_exist
+    title: openpyxl options.filename must point to an existing file
+    severity: error
+    category: project_resource
+    applies_to: entities.*
+    when:
+      type: openpyxl
+    check:
+      kind: project_file_exists
+      file: options.filename
+    message: "options.filename '{{ options.filename }}' does not exist."
+    fix: "Check the path relative to the project file. Verify the file name and extension (.xlsx)."
+    confidence: high
+    source:
+      - kind: loader
+        path: src/loaders/excel_loaders.py
+        symbol: OpenPyxlLoader
+        note: "OpenPyxlLoader raises FileNotFoundError if the file does not exist."
+
+  - id: entity.csv.filename_must_exist
+    title: csv options.filename must point to an existing file
+    severity: error
+    category: project_resource
+    applies_to: entities.*
+    when:
+      type: csv
+    check:
+      kind: project_file_exists
+      file: options.filename
+    message: "options.filename '{{ options.filename }}' does not exist."
+    fix: "Check the path relative to the project file. Verify the file name and extension."
+    confidence: high
+    source:
+      - kind: loader
+        path: src/loaders/file_loaders.py
+        symbol: CsvLoader
+        note: "CsvLoader raises FileNotFoundError if the file does not exist."
+
+  # ---------------------------------------------------------------------------
+  # consistency — cross-entity references must resolve
+  # ---------------------------------------------------------------------------
+
+  - id: reference.entity_must_exist
+    title: All entity references must resolve to a defined entity
+    severity: error
+    category: consistency
+    applies_to: entities.*
+    check:
+      kind: reference_resolves
+      scope: entities
+      fields:
+        - source
+        - foreign_keys[].entity
+        - append[].source
+        - merged.branches[].source
+    message: "Entity reference '{{ value }}' does not exist in entities."
+    fix: "Check the entity name for typos. Add the missing entity to the entities mapping if it is required."
+    confidence: high
+    source:
+      - kind: instructions
+        path: .github/instructions/shapeshifter-configuration.instructions.md
+        note: "Dependency rules: all dependency references must point to existing entities."
+      - kind: core
+        path: src/workflow.py
+        note: "Workflow builds a dependency graph from these references; unresolved names cause KeyError at runtime."

--- a/frontend/src/schemas/entitySchema.json
+++ b/frontend/src/schemas/entitySchema.json
@@ -298,6 +298,12 @@
           ],
           "default": null,
           "description": "Foreign key constraints"
+        },
+        "defer_dependency": {
+          "default": false,
+          "description": "Break a dependency cycle by deferring the FK link to a final pass. Use only when circular references are unavoidable.",
+          "title": "Defer Dependency",
+          "type": "boolean"
         }
       },
       "required": [
@@ -678,6 +684,142 @@
       "default": null,
       "description": "Fixed values for 'fixed' type entities",
       "title": "Values"
+    },
+    "options": {
+      "type": "object",
+      "description": "Loader-specific options. Required keys depend on entity type.",
+      "oneOf": [
+        {
+          "description": "Options for type: sqlite",
+          "properties": {
+            "filename": {
+              "type": "string",
+              "description": "Path to .db or .sqlite file"
+            }
+          },
+          "required": [
+            "filename"
+          ]
+        },
+        {
+          "description": "Options for type: access",
+          "properties": {
+            "filename": {
+              "type": "string",
+              "description": "Path to .mdb or .accdb file"
+            },
+            "ucanaccess_dir": {
+              "type": "string",
+              "description": "Path to UCanAccess library directory",
+              "default": "lib/ucanaccess"
+            }
+          },
+          "required": [
+            "filename"
+          ]
+        },
+        {
+          "description": "Options for type: csv",
+          "properties": {
+            "filename": {
+              "type": "string",
+              "description": "Path to .csv file"
+            },
+            "encoding": {
+              "type": "string",
+              "description": "File encoding",
+              "default": "utf-8"
+            },
+            "delimiter": {
+              "type": "string",
+              "description": "Field delimiter",
+              "default": ","
+            }
+          },
+          "required": [
+            "filename"
+          ]
+        },
+        {
+          "description": "Options for type: xlsx",
+          "properties": {
+            "filename": {
+              "type": "string",
+              "description": "Path to .xlsx or .xls file"
+            },
+            "sheet_name": {
+              "type": "string",
+              "description": "Sheet name to load"
+            },
+            "sanitize_header": {
+              "type": "boolean",
+              "description": "Whether to sanitize column headers to be YAML-friendly",
+              "default": true
+            }
+          },
+          "required": [
+            "filename"
+          ]
+        },
+        {
+          "description": "Options for type: openpyxl",
+          "properties": {
+            "filename": {
+              "type": "string",
+              "description": "Path to .xlsx file"
+            },
+            "sheet_name": {
+              "type": "string",
+              "description": "Sheet name to load"
+            },
+            "range": {
+              "type": "string",
+              "description": "Cell range to load (e.g., A1:D10)"
+            },
+            "sanitize_header": {
+              "type": "boolean",
+              "description": "Whether to sanitize column headers to be YAML-friendly",
+              "default": true
+            }
+          },
+          "required": [
+            "filename"
+          ]
+        }
+      ]
+    },
+    "check_functional_dependency": {
+      "default": true,
+      "description": "Whether to check functional dependency when dropping duplicates. Default True.",
+      "title": "Check Functional Dependency",
+      "type": "boolean"
+    },
+    "surrogate_name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Fixed entity type name used when the entity represents a controlled vocabulary type.",
+      "title": "Surrogate Name"
+    },
+    "type_names": {
+      "description": "Column name list for unnest type columns, referenced by @value: in other entities.",
+      "items": {
+        "type": "string"
+      },
+      "title": "Type Names",
+      "type": "array"
+    },
+    "replacements": {
+      "additionalProperties": true,
+      "description": "Value replacement rules applied during data extraction.",
+      "title": "Replacements",
+      "type": "object"
     }
   },
   "required": [],

--- a/scripts/generate_schemas.py
+++ b/scripts/generate_schemas.py
@@ -30,6 +30,7 @@ sys.path.insert(0, str(PROJECT_ROOT))
 
 from backend.app.models.entity import Entity
 from backend.app.models.project import Project
+from src.loaders.driver_metadata import DriverSchemaRegistry
 from src.target_model.models import TargetModel
 
 SCHEMA_CONFIG: dict[str, dict[str, Any]] = {
@@ -38,6 +39,7 @@ SCHEMA_CONFIG: dict[str, dict[str, Any]] = {
         "title": "ShapeShifter Entity Definition",
         "description": "Schema for a single entity definition (table/view/query configuration)",
         "remove_required": ["name"],
+        "add_loader_options": True,
         "field_patches": {
             "public_id": {
                 "set_if_missing": {
@@ -76,6 +78,63 @@ SCHEMA_CONFIG: dict[str, dict[str, Any]] = {
 }
 
 
+_FIELD_TYPE_TO_JSON_SCHEMA: dict[str, str] = {
+    "string": "string",
+    "integer": "integer",
+    "boolean": "boolean",
+    "password": "string",
+    "file_path": "string",
+}
+
+
+def build_loader_options_schema() -> dict[str, Any]:
+    """Build the options property schema from registered file-loader DriverSchemas.
+
+    Returns a JSON Schema object with a oneOf array, one entry per unique file
+    loader (aliases are deduplicated by schema.driver). Database loaders are
+    excluded because they use data_source + query, not options.
+    """
+    all_schemas = DriverSchemaRegistry.all()
+
+    seen_drivers: set[str] = set()
+    one_of: list[dict[str, Any]] = []
+
+    for driver_schema in all_schemas.values():
+        if driver_schema.category != "file":
+            continue
+        if driver_schema.driver in seen_drivers:
+            continue
+        seen_drivers.add(driver_schema.driver)
+
+        properties: dict[str, Any] = {}
+        required: list[str] = []
+
+        for field in driver_schema.fields:
+            prop: dict[str, Any] = {"type": _FIELD_TYPE_TO_JSON_SCHEMA.get(field.type, "string")}
+            if field.description:
+                prop["description"] = field.description
+            if field.default is not None:
+                prop["default"] = field.default
+            properties[field.name] = prop
+            if field.required:
+                required.append(field.name)
+
+        entry: dict[str, Any] = {
+            "description": f"Options for type: {driver_schema.driver}",
+            "properties": properties,
+        }
+        if required:
+            entry["required"] = required
+
+        one_of.append(entry)
+
+    return {
+        "type": "object",
+        "description": "Loader-specific options. Required keys depend on entity type.",
+        "oneOf": one_of,
+    }
+
+
 def apply_field_patches(properties: dict[str, Any], field_patches: dict[str, Any]) -> None:
     """Apply configured field-level schema patches in-place."""
     for field_name, patch_config in field_patches.items():
@@ -111,6 +170,9 @@ def clean_schema(schema: dict[str, Any], config: dict[str, Any]) -> dict[str, An
     if isinstance(properties, dict):
         apply_field_patches(properties, config.get("field_patches", {}))
 
+        if config.get("add_loader_options") and "options" in properties:
+            properties["options"] = build_loader_options_schema()
+
     return schema
 
 
@@ -124,10 +186,7 @@ def build_schema(model: type[Any], config: dict[str, Any]) -> dict[str, Any]:
     return clean_schema(schema, config)
 
 
-def generate_schemas(
-    output_dir: Path | None = None,
-    print_only: bool = False
-) -> dict[str, dict[str, Any]]:
+def generate_schemas(output_dir: Path | None = None, print_only: bool = False) -> dict[str, dict[str, Any]]:
     """Generate JSON schemas from configured Pydantic models.
 
     Args:


### PR DESCRIPTION
- Introduced a new README.md file in the docs/rules directory to explain the purpose and format of semantic validation rules for Shape Shifter project YAML files.
- Created semantic_rules.yml containing various validation rules for different entity types, ensuring required fields and cross-entity references are correctly defined.
- Updated entitySchema.json to include loader-specific options for various file types, such as xlsx, openpyxl, csv, and access, with required fields and descriptions.
- Enhanced generate_schemas.py to dynamically build the options schema from registered file-loader DriverSchemas, ensuring that the schema reflects the current state of available loaders and their requirements.